### PR TITLE
Increase lambda timeout

### DIFF
--- a/lib/orchestrator/lambda_monitor.ex
+++ b/lib/orchestrator/lambda_monitor.ex
@@ -124,7 +124,7 @@ defmodule Orchestrator.LambdaMonitor do
     req = ExAws.Lambda.invoke(name, %{}, %{}, invocation_type: :request_response)
     Logger.debug("About to spawn request #{inspect req}")
     # We spawn this as a task, so that we can keep receiving messages and do things like handle timeouts eventually.
-    Task.async(fn -> ExAws.request(req, region: region, http_opts: [recv_timeout: 900_000], retries: [max_attempts: 1]) end)
+    Task.async(fn -> ExAws.request(req, region: region, http_opts: [recv_timeout: 1_800_000], retries: [max_attempts: 1]) end)
   end
 
   defp lambda_function_name(%{functionName: function_name}) when not is_nil(function_name), do: lambda_function_name(function_name)


### PR DESCRIPTION
Higher than our max lambda timeout (which currently his 15 mins I believe)
15m is our longest interval currently so this should be more than enough as it's 30m

