### PR TITLE
1237 monitors not running

### DIFF
--- a/lib/orchestrator/lambda_monitor.ex
+++ b/lib/orchestrator/lambda_monitor.ex
@@ -30,7 +30,7 @@ defmodule Orchestrator.LambdaMonitor do
   def handle_info(:run, state) do
     Logger.info("Asked to run #{show(state)}")
     # Need this to tick and check everytime even if the genserver goes into overtime
-    # so can't e inside the state.task == nil
+    # so can't be inside the state.task == nil
     Process.send_after(self(), :run, state.config.intervalSecs * 1_000)
     if state.task == nil do
       Logger.info("Doing run for #{show(state)}")


### PR DESCRIPTION
Once a monitor entered `overtime` it wouldn't run again but the genserver would still be around so new children that the orchestrator tried to spawn to bring it back to life would fail.

```
2021-07-12T22:48:58.236Z | 22:48:58.235 [info] Asked to run azureaks (running) | logs/0/cbb5c0631af14c68b2241b6e45a1b49c
-- | -- | --
  | 2021-07-12T22:48:58.236Z | 22:48:58.235 [info] Skipping run for azureaks (running), marking us in overtime | logs/0/cbb5c0631af14c68b2241b6e45a1b49c
  | 2021-07-12T23:03:58.941Z | 23:03:58.940 [warn] ExAws: HTTP ERROR: :timeout for URL: "https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/monitor-azureaks-prod-azureaksMonitor/invocations" ATTEMPT: 1 | logs/0/cbb5c0631af14c68b2241b6e45a1b49c
  | 2021-07-12T23:03:58.941Z | 23:03:58.940 [error] Received task error for azureaks (in overtime), error is: :timeout
```
```
12:07:09.479 [error] Could not start child 11vyAYHSYuC4AZBcYBldJ5v with config %{checkName: nil, extraConfig: [], functionName: nil, id: "11vyAYHSYuC4AZBcYBldJ5v", intervalSecs: 900, monitor: %{id: "azureaks", instance: %{checkLastReports: [%{key: "CreateCluster", value: "2021-07-12T22:40:53.370574"}, %{key: "CreateDeployment", value: "2021-07-12T22:40:53.370574"}, %{key: "RemoveDeployment", value: "2021-07-12T22:40:53.370574"}], lastReport: "2021-07-12T22:40:53.370574", name: "us-west-2"}, logicalName: "azureaks", name: "Azure AKS"}, monitorName: "azureaks"}, error: {:already_started, #PID<0.1112.0>}
```