### PR TITLE
Switch to cloudfront distribution and runner-latest.txt

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -68,9 +68,10 @@ Therefore, the process is simple: just move every monitor from the old to the ne
    * For orchestrator and backend, on `develop` (cleanest is to commit on and then merge from the ticket 1212 branch)
    * For aws-serverless, on the ticket 1212 branch; make sure to merge/rebase upstream changes
      first. *DO NOT MERGE aws-serverless TO `develop` FOR NOW!*
-   and push; for aws-serverless, you can now run `shared/publish-new-only.sh` to publish the runner and all DLLS; then you can set the
-   run groups again, this time to `"RunDLL"` and the
-   monitor will now move from your local environment to the new style orchestrator.
+   and push; for aws-serverless, you can now run `shared/publish-new-only.sh <monitor_logical_name_all_lowercase>` to publish the 
+   monitor DLLs. If you made changes to the runner you can use `shared/publish-new-only.sh runner` to publish the runner; then you can 
+   set the run groups again, this time to `"RunDLL"` and the monitor will now move from your local environment to the new style orchestrator. 
+   Alternatively you can simply run `shared/publish-new-only.sh` to publish everything.
 1. Verify that the new style orchestrator invokes your monitor, reporting is ok, and move your ticket to Done.
 
 ## Special considerations

--- a/install-runner.sh
+++ b/install-runner.sh
@@ -5,10 +5,9 @@
 #
 set -euo pipefail
 
-# TODO once the S3 upload invalidates CloudFront, make this point there
-dist=https://canary-public-assets.s3.us-west-2.amazonaws.com/dist/monitors
+dist=https://monitor-distributions.canarymonitor.com
 
-latest=$(curl $dist/latest.txt)
+latest=$(curl $dist/runner-latest.txt)
 echo "Installing runner version $latest"
 curl $dist/runner-${latest}-linux-x64.zip >/tmp/runner.zip
 cd priv/runner


### PR DESCRIPTION
Deliberately going into `1212-cma-ex` as that is what this branched off of.

Doc updates for individual pushes and install-runner.sh updates for cloudformation.

Main PR must be merged/run first: https://github.com/Canary-Monitoring-Inc/aws-serverless/pull/627