### PR TITLE
Handle incomplete messages & dll invoker update

### DIFF
--- a/test/orchestrator/protocol_handler_test.exs
+++ b/test/orchestrator/protocol_handler_test.exs
@@ -1,0 +1,30 @@
+defmodule Orchestrator.ProtocolHandlerTest do
+  use ExUnit.Case, async: true
+  require Logger
+
+  alias Orchestrator.ProtocolHandler
+
+  test "Incomplete single message returns {:incomplete, message}" do
+    {result, _message} = ProtocolHandler.handle_message(self(), "testmonitor", "00041 Log Info Created card 6102e3cd")
+    assert result == :incomplete
+  end
+
+  test "Multiple messages where last is incomplete returns last message and :incomplete message returns {:incomplete, message}" do
+    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", "00041 Log Info Created card 6102e3cde5a2f61a44700041 Log Second Created")
+    Logger.debug(message)
+    assert result == :incomplete
+    assert message == "00041 Log Second Created"
+  end
+
+  test "Multiple complete messages will succeed with {:ok, nil}" do
+    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", "00041 Log Info Created card 6102e3cde5a2f61a44700041 Log Info Create card 6102e3cde5a2f61a4478")
+    assert result == :ok
+    assert message == :nil
+  end
+
+  test "Single complete message with leading/trailing zero's will succeed with {:ok, nil}" do
+    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", " 00041 Log Info Created card 6102e3cde5a2f61a447 ")
+    assert result == :ok
+    assert message == :nil
+  end
+end


### PR DESCRIPTION
Merging to 1212

Adds handling to protocolhandler to return the partial incomlete message to the caller with an atom noting that it was incomplete. Will only send the incomplete portions back if there are multiple messages (it will process the rest)

dll_invoker uses that info to append the next read it gets to that previous message and try again.

Hard to verify as this is hard to reproduce, most of the time dotnet runner sends the commands in single writes so please review logic. Some unit tests included for that same reason.

Deploy

1. PR Merge
2. Merge 1212 -> Develop to update develop orchestrators