### PR TITLE
Reset fetch delay to 60 seconds

### DIFF
--- a/lib/orchestrator/config_fetcher.ex
+++ b/lib/orchestrator/config_fetcher.ex
@@ -49,7 +49,7 @@ defmodule Orchestrator.ConfigFetcher do
     %State{state | current_config: new_config}
   end
 
-  defp schedule_fetch(delay \\ 10000) do
+  defp schedule_fetch(delay \\ 60000) do
     Process.send_after(self(), :fetch, delay)
   end
 end


### PR DESCRIPTION
My diff PR lowered this to 10 seconds accidentally. Resetting to 60.