### PR TITLE
Don't trim messages, it is too risky

### DIFF
--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -82,7 +82,6 @@ defmodule Orchestrator.ProtocolHandler do
   end
 
   def handle_message(pid, monitor_logical_name, message) do
-    message = String.trim(message)
     case Integer.parse(message) do
       {len, rest} ->
         message_body = String.slice(rest, 1, len)

--- a/test/orchestrator/protocol_handler_test.exs
+++ b/test/orchestrator/protocol_handler_test.exs
@@ -11,7 +11,6 @@ defmodule Orchestrator.ProtocolHandlerTest do
 
   test "Multiple messages where last is incomplete returns last message and :incomplete message returns {:incomplete, message}" do
     {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", "00041 Log Info Created card 6102e3cde5a2f61a44700041 Log Second Created")
-    Logger.debug(message)
     assert result == :incomplete
     assert message == "00041 Log Second Created"
   end
@@ -22,9 +21,8 @@ defmodule Orchestrator.ProtocolHandlerTest do
     assert message == :nil
   end
 
-  test "Single complete message with leading/trailing zero's will succeed with {:ok, nil}" do
-    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", " 00041 Log Info Created card 6102e3cde5a2f61a447 ")
-    assert result == :ok
-    assert message == :nil
+  test "Empty log message works" do
+    result = ProtocolHandler.handle_message(self(), "testmonitor", "00010 Log Debug ")
+    assert {:ok, :nil} == result
   end
 end


### PR DESCRIPTION
Especially with partial messages. We need to be a bit less relaxed in what we accept. 

Note that we can always still decide to drop the complexity here for a simple line mode protocol. Current protocol isn't cast in stone. 