### PR TITLE
1382 move scenarios timeouts into the database

### DIFF
--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -6,14 +6,7 @@ defmodule Orchestrator.Configuration do
   {
   "monitors": [
     {
-      "extra_config": null,
-      "interval_secs": 120,
-      "last_run_time": null,
-      "monitor_logical_name": "testsignal",
-      "run_spec": null,
-      "steps": []
-    },
-    {
+      "id": "23846123486712ewnfdvlkjhv",
       "extra_config": {
         "ApiToken": "<secret api token>",
         "Url": "https://canmon.jfrog.io/artifactory/example-repo-local/"
@@ -37,26 +30,6 @@ defmodule Orchestrator.Configuration do
         }
       ]
     },
-    {
-      "extra_config": {
-        "ApiToken": "<secret api token>",
-        "StoreId": "<secret store id>"
-      },
-      "interval_secs": 120,
-      "last_run_time": null,
-      "monitor_logical_name": "moneris",
-      "run_spec": null,
-      "steps": [
-        {
-          "check_logical_name": "TestPurchase",
-          "timeout_secs": 90.0,
-        },
-        {
-          "check_logical_name": "TestRefund",
-          "timeout_secs": 15.0,
-        }
-      ]
-    }
   ]
   }
   ```
@@ -92,12 +65,7 @@ defmodule Orchestrator.Configuration do
   @doc """
   Given an individual monitor config, return its unique key
   """
-  def unique_key(monitor_config) do
-    steps = monitor_config
-    |> Map.get(:steps, [])
-    |> Enum.map(fn step -> step.check_logical_name end)
-    {monitor_config.monitor_logical_name, steps}
-  end
+  def unique_key(monitor_config), do: monitor_config.id
 
   @doc """
   Given a new and old config, pick out the relevant changes and return a list of deltas. Deltas are basically

--- a/test/orchestrator/configuration_test.exs
+++ b/test/orchestrator/configuration_test.exs
@@ -9,6 +9,7 @@ defmodule Orchestrator.ConfigurationTest do
     new = %{
       monitors: [
         %{
+          id: "id-1",
           extra_config: %{},
           interval_secs: 120,
           last_run_time: nil,
@@ -33,6 +34,7 @@ defmodule Orchestrator.ConfigurationTest do
     old = %{
       monitors: [
         %{
+          id: "id-2",
           extra_config: %{},
           interval_secs: 120,
           last_run_time: nil,
@@ -55,6 +57,7 @@ defmodule Orchestrator.ConfigurationTest do
     new = %{
       monitors: [
         %{
+          id: "id-3",
           monitor_logical_name: "foodog",
           interval_secs: 120
         }
@@ -64,6 +67,7 @@ defmodule Orchestrator.ConfigurationTest do
     old = %{
       monitors: [
         %{
+          id: "id-3",
           monitor_logical_name: "foodog",
           interval_secs: 60
         }
@@ -86,6 +90,7 @@ defmodule Orchestrator.ConfigurationTest do
     new = %{
       monitors: [
         %{
+          id: "id-4",
           monitor_logical_name: "foodog",
           interval_secs: 120,
           last_run_time: ~N[2020-01-02 03:04:05],
@@ -97,6 +102,7 @@ defmodule Orchestrator.ConfigurationTest do
     old = %{
       monitors: [
         %{
+          id: "id-4",
           monitor_logical_name: "foodog",
           interval_secs: 120,
           last_run_time: ~N[2020-12-11 10:09:08],


### PR DESCRIPTION
https://trello.com/c/TzZPQBmi/1382-move-scenarios-timeouts-into-the-database

Small change - when scenarios are in the database, shortly thereafter "check_logical_name" (and other fields) have lost their meaning and will be dropped. In preparation, we now get the configuration primary key to use as an id.