### PR TITLE
Fix dying logging statement on error

### DIFF
--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -173,7 +173,7 @@ defmodule Orchestrator.ProtocolHandler do
   def handle_cast({:message, msg = <<"Step Error", rest::binary>>}, state) do
     when_current_step(msg, state, fn ->
       state = cancel_timer(state)
-      Logger.error("#{state.monitor_logical_name}: step error #{state.current_step}: #{rest} - #{@monitor_error_tag}")
+      Logger.error("#{state.monitor_logical_name}: step error #{state.current_step.check_logical_name}: #{rest} - #{@monitor_error_tag}")
       state.error_report_fun.(state.monitor_logical_name, state.current_step.check_logical_name, rest)
       # When a step errors, we are going to assume that subsequent steps will error as well.
       send_exit(state)


### PR DESCRIPTION
Step Errors have been failing on Logger.error since https://github.com/Canary-Monitoring-Inc/orchestrator/pull/29/ went in because state.current_step is now a map. 

This is also what's generating the Last Message gen_cast stuff in #ops

Switch to explicit `check_logical_name` same as next line on `error_report_fun` call.