### PR TITLE
1375 remove retry timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM canarymonitor/agent:build-base-2021.37 AS build
 COPY mix.exs mix.lock install-runner.sh ./
 #COPY config config
 COPY priv priv
-RUN ./install-runner.sh
+ARG GITHUB_REF=""
+RUN ./install-runner.sh $GITHUB_REF
 RUN mix do deps.get, deps.compile
 COPY lib lib
 #COPY rel rel

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ release:
 	echo Revision: `git rev-parse --short HEAD` >priv/build.txt
 	echo Date: `date` >>priv/build.txt
 	echo Build-Host: `hostname` >>priv/build.txt
-	docker build -t agent:`git rev-parse --short HEAD` .
+	docker build -t agent:`git rev-parse --short HEAD` --build-arg GITHUB_REF=`git rev-parse --symbolic-full-name HEAD` .
 
 local_release:
 	MIX_ENV=prod mix do compile, release --overwrite

--- a/install-runner.sh
+++ b/install-runner.sh
@@ -5,7 +5,14 @@
 #
 set -euo pipefail
 
-case "$GITHUB_REF" in
+if [ "$#" -ne 0 ]
+then
+    github_ref=$1
+else
+    github_ref=""
+fi
+
+case "$github_ref" in
     refs/heads/main)
         qualifier=""
         ;;
@@ -13,6 +20,8 @@ case "$GITHUB_REF" in
         qualifier="-preview"
         ;;
 esac
+
+echo "Using GITHUB_REF $github_ref and qualifier $qualifier"
 
 dist=https://monitor-distributions.canarymonitor.com
 


### PR DESCRIPTION
Part of https://trello.com/c/WgTqXU1k/1375-remove-retry-timeouts-in-favor-of-orchestrator-timeout-handling

Uses ARG instead of ENV so that it only exist during the build

Makes all GITREF uset the `-preview` runner other than `refs/heads/main`