### PR TITLE
Change default api host to app.metrist.io

### DIFF
--- a/lib/orchestrator/api_client.ex
+++ b/lib/orchestrator/api_client.ex
@@ -105,7 +105,7 @@ defmodule Orchestrator.APIClient do
   end
 
   defp base_url_and_headers do
-    host = System.get_env("CANARY_API_HOST", "app.canarymonitor.com")
+    host = System.get_env("CANARY_API_HOST", "app.metrist.io")
 
     transport =
       if String.starts_with?(host, ["localhost", "172."]),


### PR DESCRIPTION
### Description
Freshly messaged us this morning noting that their orchestrator was getting the following error since the rebrand. This changes the default host to app.metrist.io so that it doesn't have to follow a redirect (which it isn't setup to do at the moment).

Solved for Freshly by having them set the canaryOptional.apiHost to `app.metrist.io` but this will ensure it's correct by default without that override.

### Tested (If not tested in dev, explain)
- [x] dev

```
"** (MatchError) no match of right hand side value: {:error, %Jason.DecodeError{data: "<html>\r\n<head><title>301 Moved Permanently</title></head>\r\n<body>\r\n<center><h1>301 Moved Permanently</h1></center>\r\n</body>\r\n</html>\r\n", position: 0, token: nil}}
"
```