### PR TITLE
MET-157 Fix Orchestrator role for Terraform jobs

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -257,6 +257,7 @@ Resources:
                 Action:
                   - secretsmanager:GetSecretValue
                   - secretsmanager:DescribeSecret
+                  - secretsmanager:GetResourcePolicy
                 Resource: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${EnvironmentTagName}/*
         # Specifically for the Cognito monitor
         - PolicyName: CognitoOwner


### PR DESCRIPTION
https://metrist.atlassian.net/browse/MET-157

Terraform wants to describe secrets before accessing them, I guess. Fixes what I noticed in logs when testing: 

```
monitor=azureappservice(CreateService,PingService,DestroyService) [error] azureappservice: step error CreateService:  terraform executable   
exited with status 1                                                                                                                         
2021-11-11T19:15:27.230000+00:00 logs/orchestrator/850c133cc56d4a4191c80c3cc8274e41                                                          
2021-11-11T19:15:27.230000+00:00 logs/orchestrator/850c133cc56d4a4191c80c3cc8274e41 Error: error reading Secrets Manager Secret:             
AccessDeniedException: User:                                                                                                                 
arn:aws:sts::147803588724:assumed-role/orchestrator-dev1-OrchestratorTask-task/850c133cc56d4a4191c80c3cc8274e41 is not authorized to         
perform: secretsmanager:DescribeSecret on resource: /dev1/azure/api-token because no identity-based policy allows the                        
secretsmanager:DescribeSecret action 
```