### PR TITLE
MET-194 Send 429 errors to #ops as well

### DIFF
--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -151,7 +151,7 @@ defmodule Orchestrator.MonitorScheduler do
     end
   end
 
-  @dotnet_http_error_match ~r/HttpRequestException.*(40[13])/
+  @dotnet_http_error_match ~r/HttpRequestException.*(40[13]|429)/
 
   def monitor_error_handler("dll", monitor_logical_name, check_logical_name, message) do
     if Orchestrator.SlackReporter.is_configured? do
@@ -170,4 +170,7 @@ defmodule Orchestrator.MonitorScheduler do
   def monitor_error_handler(_, monitor_logical_name, check_logical_name, message) do
     Orchestrator.APIClient.write_error(monitor_logical_name, check_logical_name, message)
   end
+
+  # Purely for testing the regex
+  def dotnet_http_error_match, do: @dotnet_http_error_match
 end

--- a/test/orchestrator/monitor_scheduler_test.exs
+++ b/test/orchestrator/monitor_scheduler_test.exs
@@ -20,4 +20,14 @@ defmodule Orchestrator.MonitorSchedulerTest do
     interval = 60
     assert time_to_next_run(last_run, interval, now) == 27
   end
+
+  test "401 style errors go to Slack" do
+    error = "You are talking too much, go away (HttpRequestException 401)"
+    assert [_match, _capture] = Regex.run(dotnet_http_error_match(), error)
+  end
+
+  test "429 style errors go to Slack" do
+    error = "You are talking too much, go away (HttpRequestException 429)"
+    assert [_match, _capture] = Regex.run(dotnet_http_error_match(), error)
+  end
 end


### PR DESCRIPTION
https://metrist.atlassian.net/browse/MET-194

Pretty much WISOTT. I don't understand why we only do this for DLL-style monitors, though... 