### PR TITLE
MET-323 Cleanup configuration of monitors

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -43,7 +43,7 @@ Resources:
               Value: !Sub "@secret@:/${EnvironmentTagName}/slack/api-token#token"
             - Name: WEBHOOKS_API_ENDPOINT
               Value: !Sub ${WebhooksAPIEndpoint}
-            # Specifically for Cognito monitor
+            # Specifically for Cognito monitor (still in use - FIXME)
             - Name: USER_POOL
               Value: !Ref CognitoTestUserPool
             # Specifically for EC2 monitor
@@ -52,7 +52,7 @@ Resources:
             - Name: AMI_ID
               Value: !Ref AmiId
             # Specifically for Kinesis monitor
-            - Name: KINESIS_STREAM_NAME
+            - Name: KINESIS_STREAM_NAME (still in use - FIXME)
               Value: !Ref KinesisMonitorStream
             # Specifically for SES monitor
             - Name: SES_FROM_EMAIL
@@ -88,11 +88,6 @@ Resources:
                   !Sub "${PagerdutyStackName}-${EnvironmentTagName}-WebhooksQueueUrl"
             - Name: PAGERDUTY_SERVICE_ID
               Value: !Ref PagerdutyServiceId
-            # Specifically for Sentry monitor
-            - Name: SENTRY_QUEUE_URL
-              Value:
-                Fn::ImportValue:
-                  !Sub "${SentryStackName}-${EnvironmentTagName}-WebhooksQueueUrl"
             # Specifically for SendGrid monitor
             - Name: SENDGRID_FROM_EMAIL
               Value: !Ref SendGridFromEmail
@@ -367,17 +362,6 @@ Resources:
                 Resource:
                   Fn::ImportValue:
                     !Sub "${PagerdutyStackName}-${EnvironmentTagName}-WebhooksQueueArn"
-        # Specifically for the Sentry monitor
-        - PolicyName: SentryReadWriteQueue
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - sqs:*
-                Resource:
-                  Fn::ImportValue:
-                    !Sub "${SentryStackName}-${EnvironmentTagName}-WebhooksQueueArn"
         # Needed for Terraform things
         - PolicyName: TerraformStatsAccess
           PolicyDocument:
@@ -531,10 +515,6 @@ Parameters:
   PagerdutyServiceId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /<EnvironmentName>/monitors/pagerduty/serviceId
-  # For Sentry monitor
-  SentryStackName:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/stacks/sentryStackName
   # For Sendgrid monitor
   SendGridFromEmail:
     Type: AWS::SSM::Parameter::Value<String>

--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -54,11 +54,6 @@ Resources:
             # Specifically for Kinesis monitor
             - Name: KINESIS_STREAM_NAME (still in use - FIXME)
               Value: !Ref KinesisMonitorStream
-            # Specifically for SES monitor
-            - Name: SES_FROM_EMAIL
-              Value: !Ref SESFromEmail
-            - Name: SES_TO_EMAIL
-              Value: !Ref SESToEmail
             # Specifically for SQS monitor
             - Name: QUEUE_URL
               Value: !Ref SQSTestQueue
@@ -493,13 +488,6 @@ Parameters:
   StackTagName:
     Type: String
     Description: Stack Name (injected by Stackery at deployment time)
-   # For SES monitor
-  SESFromEmail:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/email/defaultFromEmail
-  SESToEmail:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/email/sesToEmail
   # For Heroku monitor
   HerokuStackName:
     Type: AWS::SSM::Parameter::Value<String>

--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -71,16 +71,6 @@ Resources:
               Value:
                 Fn::ImportValue:
                   !Sub "${HerokuStackName}-${EnvironmentTagName}-WebhooksQueueUrl"
-            # Specifically for Github monitor
-            - Name: GITHUB_QUEUE_URL
-              Value:
-                Fn::ImportValue:
-                  !Sub "${GithubStackName}-${EnvironmentTagName}-WebhooksQueueUrl"
-            # Specifically for Pagerduty monitor
-            - Name: PAGERDUTY_QUEUE_URL
-              Value:
-                Fn::ImportValue:
-                  !Sub "${PagerdutyStackName}-${EnvironmentTagName}-WebhooksQueueUrl"
             - Name: PAGERDUTY_SERVICE_ID
               Value: !Ref PagerdutyServiceId
             # Specifically for SendGrid monitor
@@ -335,28 +325,6 @@ Resources:
                 Resource:
                   Fn::ImportValue:
                     !Sub "${HerokuStackName}-${EnvironmentTagName}-WebhooksQueueArn"
-        # Specifically for the Github monitor
-        - PolicyName: GithubReadWriteQueue
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - sqs:*
-                Resource:
-                  Fn::ImportValue:
-                    !Sub "${GithubStackName}-${EnvironmentTagName}-WebhooksQueueArn"
-        # Specifically for the Pagerduty monitor
-        - PolicyName: PagerdutyReadWriteQueue
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - sqs:*
-                Resource:
-                  Fn::ImportValue:
-                    !Sub "${PagerdutyStackName}-${EnvironmentTagName}-WebhooksQueueArn"
         # Needed for Terraform things
         - PolicyName: TerraformStatsAccess
           PolicyDocument:
@@ -492,14 +460,7 @@ Parameters:
   HerokuStackName:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /<EnvironmentName>/stacks/herokuStackName
-  # For Github monitor
-  GithubStackName:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/stacks/githubStackName
   # For Pagerduty monitor
-  PagerdutyStackName:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/stacks/pagerDutyStackName
   PagerdutyServiceId:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /<EnvironmentName>/monitors/pagerduty/serviceId


### PR DESCRIPTION
This cleans up the configuration in concert with a backend custom Mix task (https://github.com/Metrist-Software/backend/pull/268) so that we require much less environment variables and specific config to run monitors.