### PR TITLE
MET-296 Add tag file upload to S3 for Sup-style deploys

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -69,3 +69,24 @@ prod)
   wait
   ;;
 esac
+
+# This is for GCP and hopefully at some point in time also for AWS. Maybe there is duplication
+# with the code above, but that's so that we can just throw away everything and keep just this
+# bit here.
+#
+
+case "${GITHUB_REF:-}" in
+    refs/heads/main)
+        qualifier=""
+        ;;
+    *)
+        qualifier="-preview"
+        ;;
+esac
+
+version=$(git rev-parse --short HEAD)
+image_tag=canarymonitor/agent:$version
+
+tag_file=orchestrator-latest$qualifier.txt
+echo $image_tag >/tmp/$tag_file
+aws s3 cp --region=us-west-2 /tmp/$tag_file s3://canary-private/version-stamps/$tag_file


### PR DESCRIPTION
Orchestrator on GCP is deployed with Sup. This copies the tag file upload code from the equivalent script we use for backend, so that Sup knows what to deploy. Should be merged (and the tag file verified post build) before the infrastructure stuff gets deployed.