### PR TITLE
MET-411 Bring back old domains for IPA default config, quicker than a full clean of our parameter stores

### DIFF
--- a/lib/orchestrator/ipa_server.ex
+++ b/lib/orchestrator/ipa_server.ex
@@ -65,7 +65,7 @@ defmodule Orchestrator.IPAServer do
           parse_config_file(file)
       end
 
-    Logger.info("Started listening on port #{@port} for IPA messages")
+    Logger.info("IPA: Started listening on port #{@port} for messages")
 
     {:ok, config}
   end
@@ -79,7 +79,7 @@ defmodule Orchestrator.IPAServer do
     try do
       handle_message(cleaned_msg, config)
     rescue
-      e -> Logger.error("Got error processing #{inspect(msg)}: #{Exception.format(:error, e, __STACKTRACE__)}")
+      e -> Logger.error("IPA: Got error processing #{inspect(msg)}: #{Exception.format(:error, e, __STACKTRACE__)}")
     end
 
     {:noreply, config}
@@ -107,17 +107,17 @@ defmodule Orchestrator.IPAServer do
   end
 
   def handle_message(other, _config) do
-    Logger.error("Unknown message <<#{inspect(other)}>>, skipping")
+    Logger.error("IPA: Unknown message <<#{inspect(other)}>>, skipping")
   end
 
   def maybe_send(method, host, path, value, config) do
     case Enum.find(config, fn {_, v} -> matches?(method, host, path, v) end) do
       {{m, c}, v} ->
         {value, _} = Float.parse(value)
-        Logger.info("We are sending (m=#{method} h=#{host} p=#{path} δt=#{value}) as (mon=#{m} chk=#{c}) because #{inspect(v)} matches")
+        Logger.info("IPA: We are sending (m=#{method} h=#{host} p=#{path} δt=#{value}) as (mon=#{m} chk=#{c}) because #{inspect(v)} matches")
         Orchestrator.APIClient.write_telemetry(m, c, value)
       _ ->
-        Logger.info("#{method}/#{host}/#{path} does not match anything in our configuration")
+        Logger.info("IPA: #{method}/#{host}/#{path} does not match anything in our configuration")
     end
   end
 


### PR DESCRIPTION
Turns out IPA monitoring in the orchestrator is broken because we optimistically changed the default config to the new domain, however, the old domain is still in use:

```
022-02-08T14:55:36.942000+00:00 logs/orchestrator/5511318abeec471eb726ddfd54283989 14:55:36.942 [info]  POST/appapi-dev.canarymonitor.com//api/agent/telemetry does not match anything in our configuration
```

Ideally, we make sure that our parameter stores are fully terraformed first (and unused entries are cleaned up), but there's currently still a mix of new TF based stuff and old CF based stuff, untangling that all feels like out of scope for this ticket (and not very important to start with) especially if we want to move away from the `prod-mon-....` "fake" environments first, etc. So doubling up the rules for both domain names smells like the simplest fix for now.