### PR TITLE
Add metadata as fourth argument

### DIFF
--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -158,14 +158,14 @@ defmodule Orchestrator.MonitorScheduler do
   end
 
   def get_monitor_error_handler(run_type) do
-    fn monitor_logical_name, check_logical_name, message ->
-      monitor_error_handler(run_type, monitor_logical_name, check_logical_name, message)
+    fn monitor_logical_name, check_logical_name, message, metadata ->
+      monitor_error_handler(run_type, monitor_logical_name, check_logical_name, message, metadata)
     end
   end
 
   @dotnet_http_error_match ~r/HttpRequestException.*(40[13]|429)/
 
-  def monitor_error_handler("dll", monitor_logical_name, check_logical_name, message) do
+  def monitor_error_handler("dll", monitor_logical_name, check_logical_name, message, metadata) do
     if Orchestrator.SlackReporter.is_configured? do
       with [_match, status] <- Regex.run(@dotnet_http_error_match, message) do
         Orchestrator.SlackReporter.send_monitor_error(
@@ -176,11 +176,11 @@ defmodule Orchestrator.MonitorScheduler do
       end
     end
 
-    monitor_error_handler(nil, monitor_logical_name, check_logical_name, message)
+    monitor_error_handler(nil, monitor_logical_name, check_logical_name, message, metadata)
   end
 
-  def monitor_error_handler(_, monitor_logical_name, check_logical_name, message) do
-    Orchestrator.APIClient.write_error(monitor_logical_name, check_logical_name, message, %{})
+  def monitor_error_handler(_, monitor_logical_name, check_logical_name, message, metadata) do
+    Orchestrator.APIClient.write_error(monitor_logical_name, check_logical_name, message, metadata)
   end
 
   # Purely for testing the regex


### PR DESCRIPTION
### Description
Orchestrator is not able to send errors because of it's using /3 instead of /4 arity


### Tested (If not tested in dev, explain)
- [ ] local
- [x] dev - [Testsignal](https://app-dev1.metrist.io/monitors/testsignal/errors) is now getting errors

