### PR TITLE
MET-530: Add blocked_steps when sending errors to backend

### DIFF
--- a/lib/orchestrator/api_client.ex
+++ b/lib/orchestrator/api_client.ex
@@ -30,26 +30,28 @@ defmodule Orchestrator.APIClient do
     config
   end
 
-  @spec write_telemetry(String.t(), String.t(), float(), metadata())  :: {:ok, pid}
-  def write_telemetry(monitor_logical_name, check_logical_name, value, metadata) do
+  @spec write_telemetry(String.t(), String.t(), float(), [metadata: metadata()])  :: {:ok, pid}
+  def write_telemetry(monitor_logical_name, check_logical_name, value, opts \\ []) do
     post_with_retries("telemetry", %{
       monitor_logical_name: monitor_logical_name,
       instance_name: Orchestrator.Application.instance(),
       check_logical_name: check_logical_name,
       value: value,
-      metadata: metadata
+      metadata: opts[:metadata] || %{},
     })
   end
 
-  @spec write_error(String.t(), String.t(), String.t(), metadata())  :: {:ok, pid}
-  def write_error(monitor_logical_name, check_logical_name, message, metadata) do
+  @type write_error_opts :: [metadata: metadata(), blocked_steps: [binary()]]
+  @spec write_error(String.t(), String.t(), String.t(), write_error_opts()) :: {:ok, pid}
+  def write_error(monitor_logical_name, check_logical_name, message, opts \\ []) do
     post_with_retries("error", %{
       monitor_logical_name: monitor_logical_name,
       instance_name: Orchestrator.Application.instance(),
       check_logical_name: check_logical_name,
       message: message,
       time: NaiveDateTime.utc_now(),
-      metadata: metadata
+      metadata: opts[:metadata] || %{},
+      blocked_steps: opts[:blocked_steps] ||  []
     })
   end
 

--- a/lib/orchestrator/ipa_server.ex
+++ b/lib/orchestrator/ipa_server.ex
@@ -115,7 +115,7 @@ defmodule Orchestrator.IPAServer do
       {{m, c}, v} ->
         {value, _} = Float.parse(value)
         Logger.info("IPA: We are sending (m=#{method} h=#{host} p=#{path} δt=#{value}) as (mon=#{m} chk=#{c}) because #{inspect(v)} matches")
-        Orchestrator.APIClient.write_telemetry(m, c, value, %{})
+        Orchestrator.APIClient.write_telemetry(m, c, value, [])
       _ ->
         Logger.info("IPA: #{method}/#{host}/#{path} does not match anything in our configuration")
     end

--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -158,14 +158,14 @@ defmodule Orchestrator.MonitorScheduler do
   end
 
   def get_monitor_error_handler(run_type) do
-    fn monitor_logical_name, check_logical_name, message, metadata ->
-      monitor_error_handler(run_type, monitor_logical_name, check_logical_name, message, metadata)
+    fn monitor_logical_name, check_logical_name, message, opts ->
+      monitor_error_handler(run_type, monitor_logical_name, check_logical_name, message, opts)
     end
   end
 
   @dotnet_http_error_match ~r/HttpRequestException.*(40[13]|429)/
 
-  def monitor_error_handler("dll", monitor_logical_name, check_logical_name, message, metadata) do
+  def monitor_error_handler("dll", monitor_logical_name, check_logical_name, message, opts) do
     if Orchestrator.SlackReporter.is_configured? do
       with [_match, status] <- Regex.run(@dotnet_http_error_match, message) do
         Orchestrator.SlackReporter.send_monitor_error(
@@ -176,11 +176,11 @@ defmodule Orchestrator.MonitorScheduler do
       end
     end
 
-    monitor_error_handler(nil, monitor_logical_name, check_logical_name, message, metadata)
+    monitor_error_handler(nil, monitor_logical_name, check_logical_name, message, opts)
   end
 
-  def monitor_error_handler(_, monitor_logical_name, check_logical_name, message, metadata) do
-    Orchestrator.APIClient.write_error(monitor_logical_name, check_logical_name, message, metadata)
+  def monitor_error_handler(_, monitor_logical_name, check_logical_name, message, opts) do
+    Orchestrator.APIClient.write_error(monitor_logical_name, check_logical_name, message, opts)
   end
 
   # Purely for testing the regex

--- a/test/orchestrator/protocol_handler_test.exs
+++ b/test/orchestrator/protocol_handler_test.exs
@@ -46,20 +46,20 @@ defmodule Orchestrator.ProtocolHandlerTest do
       state = mkstate()
 
       ProtocolHandler.handle_cast({:message, "Step OK"}, state)
-      assert_received {:telemetry, "mon", "check", _, %{}}
+      assert_received {:telemetry, "mon", "check", _, [metadata: %{}]}
 
       ProtocolHandler.handle_cast({:message, "Step OK key1=value1"}, state)
-      assert_received {:telemetry, "mon", "check", _, %{"key1" => "value1"}}
+      assert_received {:telemetry, "mon", "check", _, [metadata: %{"key1" => "value1"}]}
     end
 
     test "Metadata is handled correctly for monitor-timed steps" do
       state = mkstate()
 
       ProtocolHandler.handle_cast({:message, "Step Time 12.34"}, state)
-      assert_received {:telemetry, "mon", "check", 12.34, %{}}
+      assert_received {:telemetry, "mon", "check", 12.34, [metadata: %{}]}
 
       ProtocolHandler.handle_cast({:message, "Step Time key1=value1,key2=3432 12.34"}, state)
-      assert_received {:telemetry, "mon", "check", 12.34, %{"key1" => "value1", "key2" => 42.0}}
+      assert_received {:telemetry, "mon", "check", 12.34, [metadata: %{"key1" => "value1", "key2" => 42.0}]}
     end
 
     test "Metadata is handled correctly for errored steps" do
@@ -67,13 +67,13 @@ defmodule Orchestrator.ProtocolHandlerTest do
       capture_log(fn ->
 
         ProtocolHandler.handle_cast({:message, "Step Error The cake is a lie"}, state)
-        assert_received {:error, "mon", "check", "The cake is a lie", %{}}
+        assert_received {:error, "mon", "check", "The cake is a lie", [metadata: %{}, blocked_steps: _]}
 
         ProtocolHandler.handle_cast({:message, "Step Error key=value The cake really is a lie"}, state)
-        assert_received {:error, "mon", "check", "The cake really is a lie", %{"key" => "value"}}
+        assert_received {:error, "mon", "check", "The cake really is a lie", [metadata: %{"key" => "value"}, blocked_steps: _]}
 
         ProtocolHandler.handle_cast({:message, "Step Error key=value,candle The cake still is a lie"}, state)
-        assert_received {:error, "mon", "check", "key=value,candle The cake still is a lie", %{}}
+        assert_received {:error, "mon", "check", "key=value,candle The cake still is a lie", [metadata: %{}, blocked_steps: _]}
       end)
     end
   end


### PR DESCRIPTION
### Description
* Add `blocked_steps` when sending errors to the backend 

### Tested (If not tested in dev, explain)
- [ ] local
- [x] dev

### Deployment Steps
* See deploy steps https://github.com/Metrist-Software/backend/pull/505
