### PR TITLE
Hf orchestrator ipa config

### DIFF
--- a/lib/orchestrator/ipa_server.ex
+++ b/lib/orchestrator/ipa_server.ex
@@ -17,7 +17,7 @@ defmodule Orchestrator.IPAServer do
       "host" => ~r(app.*\.metrist\.io),
       "url" => ~r(api/agent/run-config)
     },
-    {"canary", "GetRunConfig"} => %{
+    {"metrist", "GetRunConfig"} => %{
       "method" => ~r(GET),
       "host" => ~r(app.*\.canarymonitor\.com),
       "url" => ~r(api/agent/run-config)
@@ -29,7 +29,7 @@ defmodule Orchestrator.IPAServer do
       "host" => ~r(app.*\.metrist\.io),
       "url" => ~r(api/agent/telemetry)
     },
-    {"canary", "SendTelemetry"} => %{
+    {"metrist", "SendTelemetry"} => %{
       "method" => ~r(POST),
       "host" => ~r(app.*\.canarymonitor\.com),
       "url" => ~r(api/agent/telemetry)


### PR DESCRIPTION
### Description
canarymonitor domains got removed from ipa config again but the orchestrators are still using canarymonitor.com domains. GetRunConfig/SendTelemetry ultimately didn't get any data for the last 24 hours because of it and they are now blank.

This adds those back in until we can properly switch all domains for the orchestrator to metrist.io domains which only makes sense to do in the new TF versions. AWS will be changing to the TF/EC2 versions shortly.

MET-760 added to remind us to change the domains for these API hits.

Tested in `dev`
