### PR TITLE
Add NEW_ENVIRONMENT_TAG env for aws orchs

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -37,10 +37,7 @@ Resources:
             # TODO: For the transition from prod-mon- style env tags to just prod
             # Remove and this and switch anything using it back to just `ENVIRONMENT_TAG` once everything is using new style
             - Name: NEW_ENVIRONMENT_TAG
-              Value: !If
-                - !Ref IsDev
-                - "dev1"
-                - "prod"
+              Value: !If [IsDev, "dev1", "prod"]
             - Name: SECRETS_NAMESPACE
               Value: !Sub /${EnvironmentTagName}/
             - Name: CANARY_INVOCATION_STYLE


### PR DESCRIPTION
### Description
Adds a `NEW_ENVIRONMENT_TAG` env for the aws orchestrators in order to transition away from `prod2`, `prod-mon..` style ENVIRONMNET_TAG values

### Trello Item (if applicable)
N/A

### Tested (If not tested in dev, explain)
- [x] local
- [x] dev

### Deployment Steps
Merge

### Related PRs (if any)
Adding followup cleanup to MET-323 to remove this and change ENVIRONMENT_TAG to just use `prod`
