### PR TITLE
Update access secrets resources

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -278,7 +278,7 @@ Resources:
                   - secretsmanager:GetResourcePolicy
                 Resource:
                   - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${EnvironmentTagName}/*
-                  - !If
+                  - !If # TODO: Remove this once EnvironmentTagName is transitioned to only use `dev1`/`prod`
                     - IsDev
                     - !Ref AWS::NoValue # Don't need anything for dev since the above covers it
                     - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/prod/*


### PR DESCRIPTION
### Description
Updates the AccessSecrets policy to include `/prod/*` secrets, similar to what's in infra. Similar to the `NEW_ENVIRONMENT_TAG` env, this should be removed once things have been transitioned

### Tested (If not tested in dev, explain)
- [x] local
- [x] dev

### Deployment Steps
Merge