### PR TITLE
MET-787: Use AWS_SECRETS_MANAGER_REGION to tell which region Orchestrator should pull the secrets from

### DIFF
--- a/lib/orchestrator/aws_secrets_manager.ex
+++ b/lib/orchestrator/aws_secrets_manager.ex
@@ -43,7 +43,7 @@ defmodule Orchestrator.AWSSecretsManager do
   end
 
   defp do_aws_request(request) do
-    region = System.get_env("AWS_REGION") || "us-east-1"
+    region = System.get_env("AWS_SECRETS_MANAGER_REGION") || System.get_env("AWS_REGION", "us-east-1")
     ExAws.request(request, region: region)
   end
 end


### PR DESCRIPTION
### Description
* Use AWS_SECRETS_MANAGER_REGION to tell which region Orchestrator should pull the secrets from

### Trello Item (if applicable)
MET-787

### Tested (If not tested in dev, explain)
- [ ] local
- [x] dev - Verified by sshing into the instance and printing the env var

### Deployment Steps
See https://github.com/Metrist-Software/infra/pull/35
