### PR TITLE
MET-328: Remove EC2 related resource

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -52,11 +52,6 @@ Resources:
               Value: !Sub "@secret@:/${EnvironmentTagName}/slack/api-token#token"
             - Name: WEBHOOKS_API_ENDPOINT
               Value: !Sub ${WebhooksAPIEndpoint}
-            # Specifically for EC2 monitor
-            - Name: PERSISTENT_INSTANCE_ID
-              Value: !Ref PersistentInstanceId
-            - Name: AMI_ID
-              Value: !Ref AmiId
             # Specifically for Heroku monitor
             - Name: HEROKU_QUEUE_URL
               Value:
@@ -262,15 +257,6 @@ Resources:
                     - IsDev
                     - !Ref AWS::NoValue # Don't need anything for dev since the above covers it
                     - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/prod/*
-        # Specifically for the EC2 monitor
-        - PolicyName: EC2FullAccess
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:*
-                Resource: '*'
         # Specifically for the Heroku monitor
         - PolicyName: HerokuReadWriteQueue
           PolicyDocument:
@@ -415,13 +401,6 @@ Parameters:
   OpsChannel:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /<EnvironmentName>/internal/opsChannel
-  # For EC2 monitor
-  PersistentInstanceId:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/monitors/ec2/persistentInstanceId
-  AmiId:
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /<EnvironmentName>/monitors/ec2/amiId
   StackTagName:
     Type: String
     Description: Stack Name (injected by Stackery at deployment time)


### PR DESCRIPTION
### Description
Remove EC2 related resources

### Trello Item (if applicable)
MET-328

### Tested (If not tested in dev, explain)
- [ ] local
- [ ] dev

### Deployment Steps
- See https://github.com/Metrist-Software/aws-serverless/pull/797

