### PR TITLE
MET-796

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['24.3.4']
+        otp: ['24.3.4.1']
         elixir: ['1.13.4']
 
     steps:


### PR DESCRIPTION
### Description
Pins to the newer, more specific OTP version 24.3.4.1 to avoid invalid cache hits. This is already being used since it's what the action pulled in for "24.3.4" previously

### Jira Item (if applicable)
MET-796

### Tested (If not tested in dev, explain)
- [x] local
- [x] dev

### Deployment Steps
1. Merge

### Related PRs (if any)
https://github.com/Metrist-Software/backend/pull/548
