### PR TITLE
Needed for ecs

### DIFF
--- a/orchestrator.yaml
+++ b/orchestrator.yaml
@@ -268,7 +268,7 @@ Resources:
                 Resource:
                   Fn::ImportValue:
                     !Sub "${HerokuStackName}-${EnvironmentTagName}-WebhooksQueueArn"
-        # Specifically neded for awsecs monitor
+        # Specifically for awsecs monitor
         - PolicyName: EC2FullAccess
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
### Description
awsecs apparently needs this permission. EC2 changes removed it.
