### PR TITLE
Set erlef/setup-beam@v1 action to use version-type strict option

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
       with:
         elixir-version: ${{matrix.elixir}}
         otp-version: ${{matrix.otp}}
+        version-type: strict
 
     - name: Restore dependencies cache
       uses: actions/cache@v2


### PR DESCRIPTION
Needed to prevent silently updating the erlang version and getting and 'old PLT' error when using cached PLT. Already added to action in backend repo