### PR TITLE
Cleanups and extra tests for config change handling

### DIFF
--- a/lib/orchestrator/config_fetcher.ex
+++ b/lib/orchestrator/config_fetcher.ex
@@ -44,7 +44,7 @@ defmodule Orchestrator.ConfigFetcher do
   defp run_fetch(state) do
     try do
       new_config = state.config_fetch_fun.()
-      deltas = Orchestrator.Configuration.diff_config(new_config, state.current_config)
+      deltas = Orchestrator.Configuration.diff_and_store_config(new_config, state.current_config)
       Logger.info("- deltas: add=#{length(deltas.add)} delete=#{length(deltas.delete)} change=#{length(deltas.change)}")
       Orchestrator.MonitorSupervisor.process_deltas(state.monitor_supervisor_pid, deltas)
       %State{state | current_config: new_config}

--- a/lib/orchestrator/monitor_supervisor.ex
+++ b/lib/orchestrator/monitor_supervisor.ex
@@ -60,6 +60,7 @@ defmodule Orchestrator.MonitorSupervisor do
     Enum.map(monitor_configs, fn monitor_config ->
       name = child_name(supervisor_name, Orchestrator.Configuration.unique_key(monitor_config))
       monitor_config = Orchestrator.Configuration.translate_config(monitor_config)
+      Logger.info("Sending config change signal to child for #{inspect monitor_config}")
       GenServer.cast(name, {:config_change, monitor_config})
     end)
   end


### PR DESCRIPTION
While digging into roll-out issues, it looked like configuration changes weren't propagating; we had to unschedule and reschedule monitors. 

The code looks good though, but a critical log statement is missing to be sure the next time around. Therefore, added logging; also renamed a method to make it more clear what it was doing, added some docs, and a test specific to the kind of config change that was made when the issues appeared.