### PR TITLE
Allow for null extra_config

### DIFF
--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -132,7 +132,7 @@ defmodule Orchestrator.Configuration do
     |> Map.put(
       :extra_config,
       monitor_config
-      |> Map.get(:extra_config, %{})
+      |> Map.get(:extra_config, %{}) || %{}
       |> Enum.map(fn {k, v} -> {k, translate_value(v)} end)
       |> Map.new()
     )

--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -131,8 +131,7 @@ defmodule Orchestrator.Configuration do
     monitor_config
     |> Map.put(
       :extra_config,
-      monitor_config
-      |> Map.get(:extra_config, %{}) || %{}
+      (Map.get(monitor_config, :extra_config, %{}) || %{})
       |> Enum.map(fn {k, v} -> {k, translate_value(v)} end)
       |> Map.new()
     )

--- a/test/orchestrator/configuration_test.exs
+++ b/test/orchestrator/configuration_test.exs
@@ -168,4 +168,11 @@ defmodule Orchestrator.ConfigurationTest do
     # asserts no updates were done.
     assert get_config("id-4") == nil
   end
+
+  # Nil extra configs was throwing protocol Enumerable not implemented for nil of type Atom
+  # and we don have monitors with nil configs
+  test "nil extra config doens't error" do
+    config = Orchestrator.Configuration.translate_config(%{extra_config: nil})
+    assert config == %{extra_config: %{}, run_spec: %{}}
+  end
 end

--- a/test/orchestrator/configuration_test.exs
+++ b/test/orchestrator/configuration_test.exs
@@ -170,7 +170,7 @@ defmodule Orchestrator.ConfigurationTest do
   end
 
   # Nil extra configs was throwing protocol Enumerable not implemented for nil of type Atom
-  # and we don have monitors with nil configs
+  # and we do have monitors with nil configs
   test "nil extra config doens't error" do
     config = Orchestrator.Configuration.translate_config(%{extra_config: nil})
     assert config == %{extra_config: %{}, run_spec: %{}}


### PR DESCRIPTION
If extra_config was null, `protocol Enumerable not implemented for nil of type Atom` would be thrown as it tried to run Enum.map against nil