### PR TITLE
Using byte_size instead of String.length in the protocol

### DIFF
--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -97,7 +97,7 @@ defmodule Orchestrator.ProtocolHandler do
     case Integer.parse(message) do
       {len, rest} ->
         message_body = String.slice(rest, 1, len)
-        if (len > String.length(message_body)) do
+        if (len > byte_size(message_body)) do
           # Incomplete message
           # Send message back if we can't process it
           # so that future data can be appended
@@ -108,7 +108,7 @@ defmodule Orchestrator.ProtocolHandler do
           handle_message(pid, monitor_logical_name, String.slice(rest, 1 + len, 100_000))
         end
       :error ->
-        if String.length(message) > 0 do
+        if byte_size(message) > 0 do
           {:error, message}
         else
           # This is actually the catch all. Odd but this
@@ -330,7 +330,7 @@ defmodule Orchestrator.ProtocolHandler do
 
   defp do_log(level, message, state) do
     message = String.trim(message)
-    if String.length(message) > 0 do
+    if byte_size(message) > 0 do
       Logger.log(level, "Received log: #{message}")
     end
     {:noreply, state}
@@ -359,7 +359,7 @@ defmodule Orchestrator.ProtocolHandler do
             # This should not happen, but if it does, we can always make a more complex read function. For now, good enough.
             # Note that technically, we can have other stuff interfering here, or multiple messages in one go, but at this
             # part in the protocol (we only get called from the handshake) we should not be too worried about that.
-            if len + 1 != String.length(rest), do: raise "Unexpected message, expected #{len} bytes, got \"#{rest}\""
+            if len + 1 != byte_size(rest), do: raise "Unexpected message, expected #{len} bytes, got \"#{rest}\""
             String.trim_leading(rest)
           :error ->
             Logger.info("Ignoring monitor output: #{data}")
@@ -374,7 +374,7 @@ defmodule Orchestrator.ProtocolHandler do
   def write(port, msg) do
     len =
       msg
-      |> String.length()
+      |> byte_size()
       |> Integer.to_string()
       |> String.pad_leading(5, "0")
     msg = len <> " " <> msg

--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -97,7 +97,7 @@ defmodule Orchestrator.ProtocolHandler do
     case Integer.parse(message) do
       {len, rest} ->
         case rest do
-          <<32, message_body::binary-size(len), new_rest::binary>> ->
+          <<" ", message_body::binary-size(len), new_rest::binary>> ->
             GenServer.cast(pid, {:message, message_body})
             # If there's more, try to process more (but it may be incomplete)
             handle_message(pid, monitor_logical_name, new_rest)

--- a/test/orchestrator/protocol_handler_test.exs
+++ b/test/orchestrator/protocol_handler_test.exs
@@ -23,7 +23,7 @@ defmodule Orchestrator.ProtocolHandlerTest do
   end
 
   test "Message with CRLF will succeed with {:ok, nil}" do
-    log = "00214 Log Debug statusCode: 500, gotIp: <html>\r\n<head><title>500 Internal Server Error</title></head>\r\n<body>\r\n<center><h1>500 Internal Server Error</h1></center>\r\n</body>\r\n</html>\r\n, theIp: ip-10-0-101-123, not done yet"
+    log = "00214 Log Debug statusCode: 500, gotIp: <html>\r\n<head><title>500 Internal Server Error</title></head>\r\n<body>\r\n<center><h1>500 Internal Server Error</h1></center>\r\n</body>\r\n</html>\r\n, theIp: ip-11-1-111-111, not done yet"
     {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", log)
     assert result == :ok
     assert message == :nil

--- a/test/orchestrator/protocol_handler_test.exs
+++ b/test/orchestrator/protocol_handler_test.exs
@@ -22,6 +22,20 @@ defmodule Orchestrator.ProtocolHandlerTest do
     assert message == :nil
   end
 
+  test "Message with CRLF will succeed with {:ok, nil}" do
+    log = "00214 Log Debug statusCode: 500, gotIp: <html>\r\n<head><title>500 Internal Server Error</title></head>\r\n<body>\r\n<center><h1>500 Internal Server Error</h1></center>\r\n</body>\r\n</html>\r\n, theIp: ip-10-0-101-123, not done yet"
+    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", log)
+    assert result == :ok
+    assert message == :nil
+  end
+
+  test "Message is complete when the number of bytes is correct" do
+    {result, message} = ProtocolHandler.handle_message(self(), "testmonitor", "00007 héllo")
+    assert message == :nil
+    assert result == :ok
+  end
+
+
   test "Empty log message works" do
     result = ProtocolHandler.handle_message(self(), "testmonitor", "00010 Log Debug ")
     assert {:ok, :nil} == result


### PR DESCRIPTION
Use the byte_size/0 to calculate the message's byte size. 

**Deployment**
See related PR 