### PR TITLE
MET-982

### DIFF
--- a/dist/ubuntu/20.04/Dockerfile
+++ b/dist/ubuntu/20.04/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV MIX_ENV=prod
 
 RUN apt-get update
-RUN apt-get install -y build-essential zstd git curl unzip wget
+RUN apt-get install -y build-essential zstd git curl unzip wget libcurl4-openssl-dev
 RUN wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb && dpkg -i erlang-solutions_2.0_all.deb
 RUN apt-get update
 RUN apt-get install -y esl-erlang elixir

--- a/dist/ubuntu/22.04/Dockerfile
+++ b/dist/ubuntu/22.04/Dockerfile
@@ -7,7 +7,7 @@ ENV MIX_ENV=prod
 
 # Jammy is not setup as a distribution by Erlang Solutions, so grab the packages manually.
 RUN apt-get update
-RUN apt-get install -y build-essential zstd git curl unzip wget
+RUN apt-get install -y build-essential zstd git curl unzip wget libcurl4-openssl-dev
 RUN wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc; apt-key add erlang_solutions.asc
 RUN wget https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_25.0.3-1~ubuntu~jammy_amd64.deb
 RUN wget https://packages.erlang-solutions.com/erlang/debian/pool/elixir_1.13.4-1~ubuntu~focal_all.deb


### PR DESCRIPTION
Add a package that the libcurl agent needs so we can reuse the docker image for its distribution build