### PR TITLE
Use the correct path to trustedkeys.gpg

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ The following steps will download and verify the debian package
     wget -nc http://dist.metrist.io/orchestrator/ubuntu/ubuntu-20.04.latest.txt
     wget -nc http://dist.metrist.io/orchestrator/ubuntu/$(cat ubuntu-20.04.latest.txt)
     wget -nc http://dist.metrist.io/orchestrator/ubuntu/$(cat ubuntu-20.04.latest.txt).asc
-    wget -nc https://github.com/Metrist-Software/orchestrator/main/dist/trustedkeys.gpg
+    wget -nc https://github.com/Metrist-Software/orchestrator/blob/main/dist/trustedkeys.gpg
     gpg --keyring ./trustedkeys.gpg --verify $(cat ubuntu-20.04.latest.txt).asc
 
 ### Installing the Debian package


### PR DESCRIPTION
This gives you a 404 https://github.com/Metrist-Software/orchestrator/main/dist/trustedkeys.gpg
```sh
wget -nc https://github.com/Metrist-Software/orchestrator/main/dist/trustedkeys.gpg
--2022-10-04 13:35:55--  https://github.com/Metrist-Software/orchestrator/main/dist/trustedkeys.gpg
Resolving github.com (github.com)... 140.82.114.3
Connecting to github.com (github.com)|140.82.114.3|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2022-10-04 13:35:56 ERROR 404: Not Found.
```


This doesnt https://github.com/Metrist-Software/orchestrator/blob/main/dist/trustedkeys.gpg