### PR TITLE
Have .NET invoker also do a download first.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,11 @@ release:
 local_release:
 	MIX_ENV=prod mix do compile, release --overwrite
 
-tail_cma_log_dev:
-	aws logs tail --region=us-east-1 --follow --since=0m /stackery/task/orchestrator-dev1-PrivateCMATask/logs
-
-tail_cma_log_prod:
-	aws logs tail --region=us-west-2 --follow --since=0m /stackery/task/orchestrator-prod-PrivateCMATask/logs
-
 tail_log_dev:
-	aws logs tail --region=us-east-1 --follow --since=0m /stackery/task/orchestrator-dev1-OrchestratorTask/logs
+	aws logs tail --region=us-east-1 --follow --since=0m dev1-orchestrator-logs
 
 tail_log_prod:
-	aws logs tail --region=us-west-2 --follow --since=0m /stackery/task/orchestrator-prod-OrchestratorTask/logs
+	aws logs tail --region=us-west-2 --follow --since=0m prod-orchestrator-logs
 
 exec_dev:
 	make AWS_REGION=us-east-1 ENV=dev1 exec

--- a/lib/orchestrator/executable_invoker.ex
+++ b/lib/orchestrator/executable_invoker.ex
@@ -6,8 +6,6 @@ defmodule Orchestrator.ExecutableInvoker do
   """
   require Logger
 
-  @monitor_distributions_url "https://monitor-distributions.metrist.io/"
-
   @behaviour Orchestrator.Invoker
 
   @impl true
@@ -32,106 +30,10 @@ defmodule Orchestrator.ExecutableInvoker do
   end
 
   defp get_executable(config) do
-    {dir, executable} = maybe_download(config.run_spec.name)
+    {dir, executable} = {Orchestrator.Invoker.maybe_download(config.run_spec.name), config.run_spec.name}
     # executable is relative to dir, make it absolute
     executable = Path.join(dir, executable)
     Path.expand(executable)
   end
 
-  defp maybe_download(name) do
-    if local_mode?() do
-      Logger.warn("Using local mode, not downloading")
-      {Path.join([local_path(), name]), name}
-    else
-      cache_or_download(name)
-    end
-  end
-
-  defp cache_or_download(name) do
-    latest = get_latest_version(name, Orchestrator.Application.preview_mode?())
-
-    if cache_disabled?() or not available?(name, latest) do
-      fetch_and_unpack_zip(name, latest)
-    end
-
-    dir_and_exe_of(name, latest)
-  end
-
-  defp get_latest_version(name, _preview_mode = true) do
-    try do
-      String.trim(download("#{name}-latest-preview.txt"))
-    rescue
-      _ -> get_latest_version(name, false)
-    end
-  end
-  defp get_latest_version(name, _preview_mode = false) do
-    String.trim(download("#{name}-latest.txt"))
-  end
-
-
-  defp fetch_and_unpack_zip(name, version) do
-    Logger.info("Fetching monitor #{name} version #{version}")
-
-    zip = download(zip_name(name, version))
-    tmp = Path.join([System.tmp_dir(), "#{name}-#{version}.zip"])
-    File.write!(tmp, zip, [:binary])
-
-    target = ensure_cache_dir(name, version)
-
-    {:ok, files} = :zip.extract(String.to_charlist(tmp), cwd: String.to_charlist(target))
-    Enum.map(files, &ensure_x_bit/1)
-    File.rm(tmp)
-  end
-
-  defp ensure_cache_dir(name, version) do
-    top_level_cache = cache_location(name)
-
-    # Delete the old version if it exists as we've now downloaded a new one
-    if File.dir?(top_level_cache) do
-      File.rm_rf(top_level_cache)
-    end
-
-    version_specific_cache = cache_location(name, version)
-    File.mkdir_p(version_specific_cache)
-
-    version_specific_cache
-  end
-
-  # A bit dirty, but Erlang's unzip does not preserve the execute bit. It does not hurt to
-  # have it on and it must be on for executables, so we set it for everything. This allows us
-  # to use the built-in zip library. Alternative would be gzip+tar.
-  defp ensure_x_bit(path) do
-    use Bitwise
-    {:ok, stat} = File.stat(path)
-    File.chmod(path, stat.mode ||| 0o110)
-  end
-
-  defp available?(name, version) do
-    loc = cache_location(name, version)
-    File.dir?(loc) and File.exists?(Path.join(loc, name))
-  end
-
-  def download(path) do
-    {:ok, %HTTPoison.Response{body: body}} = HTTPoison.get(@monitor_distributions_url <> path)
-    body
-  end
-
-  # A bunch of path/env helpers.
-
-  defp cache_location(name), do: Path.join([cache_path(), name])
-  defp cache_location(name, version), do: Path.join([cache_path(), name, version])
-
-  defp zip_name(name, version), do: "#{name}-#{version}-linux-x64.zip"
-
-  defp dir_and_exe_of(name, version), do: {cache_location(name, version), name}
-
-  defp cache_disabled?, do: System.get_env("METRIST_EXE_DISABLE_CACHE") != nil
-
-  defp local_mode?, do: local_path() != nil
-
-  defp local_path, do: System.get_env("METRIST_EXE_LOCAL_PATH")
-
-  defp cache_path, do: System.get_env("METRIST_CACHE_DIR") || default_cache_path()
-
-  defp default_cache_path, do: Path.join([System.user_home(), ".cache/metrist/monitors"])
 end

--- a/lib/orchestrator/executable_invoker.ex
+++ b/lib/orchestrator/executable_invoker.ex
@@ -12,6 +12,7 @@ defmodule Orchestrator.ExecutableInvoker do
   def invoke(config, opts \\ []) do
     Logger.debug("Invoking #{inspect(config)}")
 
+    # :executable is set for a manual monitor run
     executable = Keyword.get(opts, :executable, nil)
     executable = unless executable, do: get_executable(config), else: executable
 
@@ -31,11 +32,12 @@ defmodule Orchestrator.ExecutableInvoker do
   end
 
   defp get_executable(config) do
-    {dir, executable} =
-      {Orchestrator.Invoker.maybe_download(config.run_spec.name), config.run_spec.name}
+    name = config.run_spec.name
+    dir = Orchestrator.Invoker.maybe_download(name)
 
     # executable is relative to dir, make it absolute
-    executable = Path.join(dir, executable)
-    Path.expand(executable)
+    dir
+    |> Path.join(name)
+    |> Path.expand()
   end
 end

--- a/lib/orchestrator/executable_invoker.ex
+++ b/lib/orchestrator/executable_invoker.ex
@@ -16,24 +16,26 @@ defmodule Orchestrator.ExecutableInvoker do
     executable = unless executable, do: get_executable(config), else: executable
 
     Logger.debug("Running #{executable}")
+
     if not File.exists?(executable) do
       raise "Executable #{executable} does not exist, exiting!"
     end
 
     Orchestrator.Invoker.run_monitor(config, opts, fn ->
-        Port.open({:spawn_executable, executable}, [
-          :binary,
-          :stderr_to_stdout,
-          cd: Path.dirname(executable)
-         ])
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        :stderr_to_stdout,
+        cd: Path.dirname(executable)
+      ])
     end)
   end
 
   defp get_executable(config) do
-    {dir, executable} = {Orchestrator.Invoker.maybe_download(config.run_spec.name), config.run_spec.name}
+    {dir, executable} =
+      {Orchestrator.Invoker.maybe_download(config.run_spec.name), config.run_spec.name}
+
     # executable is relative to dir, make it absolute
     executable = Path.join(dir, executable)
     Path.expand(executable)
   end
-
 end

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -47,4 +47,104 @@ defmodule Orchestrator.Invoker do
       result
     end)
   end
+
+  # Download/caching support.
+
+  @monitor_distributions_url "https://monitor-distributions.metrist.io/"
+
+  def maybe_download(name) do
+    if local_mode?() do
+      Logger.warn("Using local mode, not downloading")
+      Path.join([local_path(), name])
+    else
+      cache_or_download(name)
+    end
+  end
+
+  defp cache_or_download(name) do
+    latest = get_latest_version(name, Orchestrator.Application.preview_mode?())
+
+    if cache_disabled?() or not available?(name, latest) do
+      fetch_and_unpack_zip(name, latest)
+    end
+
+    cache_location(name, latest)
+  end
+
+  defp get_latest_version(name, _preview_mode = true) do
+    try do
+      String.trim(download("#{name}-latest-preview.txt"))
+    rescue
+      _ -> get_latest_version(name, false)
+    end
+  end
+  defp get_latest_version(name, _preview_mode = false) do
+    String.trim(download("#{name}-latest.txt"))
+  end
+
+
+  defp fetch_and_unpack_zip(name, version) do
+    Logger.info("Fetching monitor #{name} version #{version}")
+
+    zip = download(zip_name(name, version))
+    tmp = Path.join([System.tmp_dir(), "#{name}-#{version}.zip"])
+    File.write!(tmp, zip, [:binary])
+
+    target = ensure_cache_dir(name, version)
+
+    {:ok, files} = :zip.extract(String.to_charlist(tmp), cwd: String.to_charlist(target))
+    Enum.map(files, &ensure_x_bit/1)
+    File.rm(tmp)
+  end
+
+  defp ensure_cache_dir(name, version) do
+    top_level_cache = cache_location(name)
+
+    # Delete the old version if it exists as we've now downloaded a new one
+    if File.dir?(top_level_cache) do
+      File.rm_rf(top_level_cache)
+    end
+
+    version_specific_cache = cache_location(name, version)
+    File.mkdir_p(version_specific_cache)
+
+    version_specific_cache
+  end
+
+  # A bit dirty, but Erlang's unzip does not preserve the execute bit. It does not hurt to
+  # have it on and it must be on for executables, so we set it for everything. This allows us
+  # to use the built-in zip library. Alternative would be gzip+tar.
+  defp ensure_x_bit(path) do
+    import  Bitwise
+    {:ok, stat} = File.stat(path)
+    File.chmod(path, stat.mode ||| 0o110)
+  end
+
+  defp available?(name, version) do
+    loc = cache_location(name, version)
+    File.dir?(loc) and File.exists?(Path.join(loc, name))
+  end
+
+  def download(path) do
+    {:ok, %HTTPoison.Response{body: body}} = HTTPoison.get(@monitor_distributions_url <> path)
+    body
+  end
+
+  # A bunch of path/env helpers.
+
+  defp cache_location(name), do: Path.join([cache_path(), name])
+  defp cache_location(name, version), do: Path.join([cache_path(), name, version])
+
+  defp zip_name(name, version), do: "#{name}-#{version}-linux-x64.zip"
+
+  defp cache_disabled?, do: System.get_env("METRIST_EXE_DISABLE_CACHE") != nil
+
+  defp local_mode?, do: local_path() != nil
+
+  defp local_path, do: System.get_env("METRIST_EXE_LOCAL_PATH")
+
+  defp cache_path, do: System.get_env("METRIST_CACHE_DIR") || default_cache_path()
+
+  defp default_cache_path, do: Path.join([System.user_home(), ".cache/metrist/monitors"])
+
 end

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -52,6 +52,24 @@ defmodule Orchestrator.Invoker do
 
   @monitor_distributions_url "https://monitor-distributions.metrist.io/"
 
+  @doc """
+  Download the archive for the monitor with name `name` and unpack it. Unless disabled
+  through a `METRIST_EXE_DISABLE_CACHE` this will check whether the most recent version
+  is already available and just return a cache location instead.
+
+  Full list of environment variables that influence the behaviour of this function:
+
+  * `METRIST_EXE_DISABLE_CACHE` - disable cache lookup, will always download the archive.
+  * `METRIST_EXE_LOCAL_PATH` - override download, use the indicated local path instead. Will not
+    talk to external servers.
+  * `METRIST_CACHE_DIR` - where to store downloaded archives. By default `~/.cache/metrist/monitors`
+
+  Unless disabled by setting the local path, it will always fetch the most recent version for the
+  monitor from `@monitor_distributions_url`.
+
+  Returns the path to the unpacked archive.
+  """
+  @spec maybe_download(name :: String.t()) :: String.t()
   def maybe_download(name) do
     if local_mode?() do
       Logger.warn("Using local mode, not downloading")


### PR DESCRIPTION
This ensures that we only have a single place to download (until now, downloads are done inside the .NET wrapper code). We will now always pass the path argument to the DLL wrapper code whether we run in test mode or not.

Internal ticket MET-672.