### PR TITLE
Force AWS secrets to be returned as strings

### DIFF
--- a/lib/orchestrator/aws_secrets_manager.ex
+++ b/lib/orchestrator/aws_secrets_manager.ex
@@ -36,6 +36,8 @@ defmodule Orchestrator.AWSSecretsManager do
             |> Jason.decode!()
             |> Map.get(selector)
         end
+        # For now, we only want to deal with string values because that's what the protocol expects
+        |> to_string()
       {:error, message} ->
         Logger.info("Secret #{name} not found, returning nil. Got message #{inspect(message)}")
         nil


### PR DESCRIPTION
Just a simple fix. We reuse the RDS connection string secret for our instance of the AWS RDS "persistent" monitor, and that one has a numeric port. The protocol sends strings over, and other places expect strings, so it makes sense to just cast to string here.

Metrist ticket MET-1034