### PR TITLE
Handle normal exit message

### DIFF
--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -93,6 +93,11 @@ defmodule Orchestrator.MonitorScheduler do
     {:noreply, %State{state | task: nil, overtime: false}}
   end
 
+  def handle_info({:EXIT, pid, :normal}, state) do
+    Logger.debug("Monitor with pid #{inspect pid} exited normally")
+    {:noreply, state}
+  end
+
   def handle_info(msg, state) do
     Logger.info("Unknown message received: #{inspect msg}")
     {:noreply, state}


### PR DESCRIPTION
This prevents us from logging "Unknown message received" on every normal monitor process exit.