### PR TITLE
MET-1102 Orchestrator memory leak

### DIFF
--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -47,8 +47,11 @@ defmodule Orchestrator.ProtocolHandler do
                                         error_report_fun,
                                         os_pid})
     result = wait_for_complete(port, ref, config.monitor_logical_name, pid)
+
     # Don't trust anything to exit voluntarily
     kill_or_close(port)
+    if Process.alive?(pid), do: GenServer.stop(pid)
+
     Logger.info("Monitor is complete")
     result
   end


### PR DESCRIPTION
Looks like the ProtocolHandler genserver processes weren't being stopped when a monitor didn't exit gracefully (specifically with an "Exit" message sent from it). We're already force killing the actual os monitor processes here to be safe, so this does the same for the genserver processes.

Currently running in dev, but it's slow to actually have the memory grow since it needs the monitor run to error