### PR TITLE
Hotfix dist builds erlexec

### DIFF
--- a/dist/amazon-linux/2/Dockerfile
+++ b/dist/amazon-linux/2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2 AS build
 
-ENV REFRESHED_AT 20220926T210646Z
+ENV REFRESHED_AT 20221202T173638Z
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MIX_ENV=prod
@@ -34,3 +34,4 @@ WORKDIR /app
 # our tooling can write to where we need.
 RUN mkdir /.mix && chmod 777 /.mix
 RUN mkdir /.hex && chmod 777 /.hex
+RUN mkdir /.cache && chmod 777 /.cache

--- a/dist/ubuntu/20.04/Dockerfile
+++ b/dist/ubuntu/20.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04 AS build
 
-ENV REFRESHED_AT 20221025T182407Z
+ENV REFRESHED_AT 20221202T173638Z
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MIX_ENV=prod
@@ -19,3 +19,4 @@ WORKDIR /app
 # our tooling can write to where we need.
 RUN mkdir /.mix && chmod 777 /.mix
 RUN mkdir /.hex && chmod 777 /.hex
+RUN mkdir /.cache && chmod 777 /.cache

--- a/dist/ubuntu/22.04/Dockerfile
+++ b/dist/ubuntu/22.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 AS build
 
-ENV REFRESHED_AT 20221025T184823Z
+ENV REFRESHED_AT 20221202T173638Z
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MIX_ENV=prod
@@ -20,3 +20,4 @@ WORKDIR /app
 # our tooling can write to where we need.
 RUN mkdir /.mix && chmod 777 /.mix
 RUN mkdir /.hex && chmod 777 /.hex
+RUN mkdir /.cache && chmod 777 /.cache

--- a/lib/mix/tasks/metrist/run_monitor.ex
+++ b/lib/mix/tasks/metrist/run_monitor.ex
@@ -41,6 +41,7 @@ defmodule Mix.Tasks.Metrist.RunMonitor do
 
   def run(args) do
     Mix.Task.run("app.config")
+    Application.ensure_started(:erlexec)
     setup_hackney_for_external_webhook_processing()
 
     {opts, []} =


### PR DESCRIPTION
Adds .cache dir to base images which is required for erlexec compilation. (Tested with a local built docker container of 20.04)
Also ensures erlexec is available in run_monitor

Deployment
Merge

Note: All dist base images have already been rebuilt and pushed
