### PR TITLE
MET-1106 third attempt / MET-1139

### DIFF
--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -24,6 +24,11 @@ defmodule Orchestrator.Invoker do
     Task.Supervisor.async_nolink(Orchestrator.TaskSupervisor, fn ->
       Orchestrator.Application.set_monitor_logging_metadata(config)
 
+      # Whatever happens, we must be able to cleanup tmpdir. So that's
+      # why we trap exits here. ProtocolHandler will stop recursing on
+      # receiving the EXIT signal.
+      Process.flag(:trap_exit, true)
+
       os_pid = start_function.(tmpdir)
       GenServer.cast(parent, {:monitor_pid, os_pid})
 

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -38,6 +38,7 @@ defmodule Orchestrator.Invoker do
       result = Orchestrator.ProtocolHandler.run_protocol(config, os_pid, opts)
 
       File.rm_rf!(tmpdir)
+      Logger.info("Monitor complete, cleanup done")
 
       result
     end)

--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -68,7 +68,6 @@ defmodule Orchestrator.ProtocolHandler do
     # itself, we do not care), so Process.spawn/2 is like the correct solution.
     if Process.alive?(pid), do: Process.spawn(fn -> GenServer.stop(pid) end, [])
 
-    Logger.info("Monitor is complete")
     result
   end
 

--- a/lib/orchestrator/protocol_handler.ex
+++ b/lib/orchestrator/protocol_handler.ex
@@ -81,6 +81,10 @@ defmodule Orchestrator.ProtocolHandler do
         Logger.info("Protocol process completed with reason #{inspect reason}")
         :ok
 
+      {:EXIT, _from, reason} ->
+        Logger.info("Process exit signal received with reason #{inspect reason}, ending protocol")
+        :ok
+
       {:stdout, ^os_pid, data} ->
         case handle_message(protocol_handler, monitor_logical_name, previous_partial_message <> data) do
           {:incomplete, message} ->


### PR DESCRIPTION
Trap and catch exit signals in the Task so that rm -rf always runs.