### PR TITLE
Ensure run_monitor has the req task supervisor

### DIFF
--- a/lib/mix/tasks/metrist/run_monitor.ex
+++ b/lib/mix/tasks/metrist/run_monitor.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Metrist.RunMonitor do
   def run(args) do
     Mix.Task.run("app.config")
     Application.ensure_started(:erlexec)
+    Task.Supervisor.start_link(name: Orchestrator.TaskSupervisor)
     setup_hackney_for_external_webhook_processing()
 
     {opts, []} =


### PR DESCRIPTION
The new invokers require a `Task.Supervisor` with name `Orchestrator.TaskSupervisor` to function. This updates the mix task to start one.