### PR TITLE
Met 1143

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -4,6 +4,6 @@ config :orchestrator,
   enable_host_telemetry?:
     System.get_env("METRIST_ENABLE_HOST_TELEMETRY", "false") |> String.to_existing_atom(),
   api_token: System.get_env("METRIST_API_TOKEN"),
+  instance_id: System.get_env("METRIST_INSTANCE_ID"),
   slack_api_token: System.get_env("SLACK_API_TOKEN"),
   slack_reporting_channel: System.get_env("SLACK_ALERTING_CHANNEL")
-

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,6 +5,7 @@ if config_env() == :prod do
     enable_host_telemetry?:
       System.get_env("METRIST_ENABLE_HOST_TELEMETRY", "false") |> String.to_existing_atom(),
     api_token: Orchestrator.Application.translate_config_from_env("METRIST_API_TOKEN"),
+    instance_id: Orchestrator.Application.translate_config_from_env("METRIST_INSTANCE_ID"),
     slack_api_token: Orchestrator.Application.translate_config_from_env("SLACK_API_TOKEN"),
     slack_reporting_channel: Orchestrator.Application.translate_config_from_env("SLACK_ALERTING_CHANNEL")
 end

--- a/dist/interactive/install.sh
+++ b/dist/interactive/install.sh
@@ -229,7 +229,13 @@ DetectOS() {
 
 INSTANCE_NAME=
 GetInstanceName() {
-    echo -n "Please enter your Instance name: "; read -r INSTANCE_NAME
+    cat <<EOF
+
+    We distinguish collected metrics and error data by "instance name", which can be a hostname,
+    a cloud region, or any other tag you want to use for grouping data.
+
+EOF
+    echo -n "Please enter the instance name you want to use on this machine: "; read -r INSTANCE_NAME
     echo
 }
 

--- a/dist/interactive/install.sh
+++ b/dist/interactive/install.sh
@@ -227,6 +227,12 @@ DetectOS() {
 
 }
 
+INSTANCE_NAME=
+GetInstanceName() {
+    echo -n "Please enter your Instance name: "; read -r INSTANCE_NAME
+    echo
+}
+
 API_KEY=
 GetAPIKey() {
     cat <<EOF
@@ -256,6 +262,7 @@ InstallApt() {
 
 # Added by installation script.
 METRIST_API_TOKEN=$API_KEY
+METRIST_INSTANCE_ID=$INSTANCE_NAME
 EOF
     $SUDO systemctl enable --now metrist-orchestrator
     $SUDO systemctl start metrist-orchestrator
@@ -279,6 +286,7 @@ InstallYum() {
 
 # Added by installation script.
 METRIST_API_TOKEN=$API_KEY
+METRIST_INSTANCE_ID=$INSTANCE_NAME
 EOF
     $SUDO systemctl enable --now metrist-orchestrator
     $SUDO systemctl start metrist-orchestrator
@@ -289,6 +297,7 @@ Main() {
     SetTty
     DetectOS
     GetAPIKey
+    GetInstanceName
 
     echo "Installing Metrist Orchestrator for $OS $VERSION."
 

--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -60,7 +60,7 @@ defmodule Orchestrator.Application do
 
   def aws_region, do: System.get_env("AWS_REGION", "fake-dev-region")
 
-  def instance, do: Application.get_env(:orchestrator, :instance_id)
+  def instance, do: Application.get_env(:orchestrator, :instance_id) || "fake-dev-instance"
 
   def slack_api_token, do: Application.get_env(:orchestrator, :slack_api_token)
 

--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -42,7 +42,7 @@ defmodule Orchestrator.Application do
     Supervisor.start_link(children, opts)
   end
 
-  def api_token, do: Application.get_env(:orchestrator, :instance_id)
+  def api_token, do: Application.get_env(:orchestrator, :api_token)
 
   def do_cleanup?, do: System.get_env("METRIST_CLEANUP_ENABLED") != nil
 

--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -42,7 +42,7 @@ defmodule Orchestrator.Application do
     Supervisor.start_link(children, opts)
   end
 
-  def instance, do: System.get_env("METRIST_INSTANCE_ID", "fake-dev-instance")
+  def api_token, do: Application.get_env(:orchestrator, :instance_id)
 
   def do_cleanup?, do: System.get_env("METRIST_CLEANUP_ENABLED") != nil
 
@@ -60,7 +60,7 @@ defmodule Orchestrator.Application do
 
   def aws_region, do: System.get_env("AWS_REGION", "fake-dev-region")
 
-  def api_token, do: Application.get_env(:orchestrator, :api_token)
+  def instance, do: Application.get_env(:orchestrator, :instance_id)
 
   def slack_api_token, do: Application.get_env(:orchestrator, :slack_api_token)
 


### PR DESCRIPTION
This adds prompting for the instance name in the installation script. Instance names really are sort of mandatory, because the default ("fake-dev-instance") is not something you'd like to see in your collected data.

(Metrist ticket MET-1143)