### PR TITLE
Fix elixir version in the build-base dockerfile

### DIFF
--- a/Dockerfile.build-base
+++ b/Dockerfile.build-base
@@ -1,4 +1,4 @@
-FROM elixir:1.41.1-slim AS build
+FROM elixir:1.14.1-slim AS build
 
 ENV REFRESHED_AT 20220926T210646Z
 RUN apt-get update


### PR DESCRIPTION
This change makes so that the base image points to a correct elixir version