### PR TITLE
Add e2e distribution tests

### DIFF
--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -48,9 +48,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('**/${{ matrix.dist }}/Vagrantfile') }}
           restore-keys: |
-            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
+            ${{ runner.os }}-vagrant-${{ hashFiles('**/${{ matrix.dist }}/Vagrantfile') }}
 
       - name: Run e2e
         env:

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -10,17 +10,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: get-all-dists
-        name: Get build chunks
+        name: Get all distributions
         run: |
           cd dist
           echo "dists=$(ls -ld */* | grep ^d | awk '{print $9}' | jq -cnMR '[inputs | select(length>0)]')" >> $GITHUB_OUTPUT
   e2e:
-    # We use this virtual environment because it supports nested virtualization.
+    # We use this runner because it is currently the only runner that supports nested virtualization.
     # See https://github.com/actions/virtual-environments/issues/433 for more
     # information
     runs-on: macos-12
     needs:
       - setup
+    permissions:
+      id-token: write
+      contents: read      
     strategy:
       fail-fast: false
       matrix: 
@@ -28,6 +31,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::147803588724:role/github-actions-shared-dist-writer
+          aws-region: us-west-2
+
+      - name: Import e2e API TOKEN
+        run: |
+          e2e_api_token=aws secretsmanager get-secret-value --secret-id /prod/gh-actions/orchestrator-e2e-token --region us-west-2 | jq -r '.SecretString'
+          echo "::add-mask::${e2e_api_token}"
+          echo "$TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
 
       - name: Cache Vagrant box
         uses: actions/cache@v3
@@ -41,12 +56,14 @@ jobs:
         run: |
           cd ./dist/${{ matrix.dist }}
           echo "Running ${{matrix.dist}}"
+          echo "ENSURE MASKING $TEST_API_TOKEN"
 
       # - name: full e2e
       #   run: |
       #     cd ./dist/${{ matrix.dist }}
       #     vagrant box update
       #     vagrant up --provision
+      #     vagrant upload ../../e2e.sh
       #     vagrant ssh -c "echo 'hello world!'"
       #     vagrant destroy -f
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -60,6 +60,6 @@ jobs:
           vagrant box update
           vagrant up --provision
           vagrant upload ../../e2e.sh
-          vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN /bin/bash /home/vagrant/e2e.sh"
+          vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN DIST=$DIST /bin/bash /home/vagrant/e2e.sh"
           vagrant destroy -f
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Import e2e API TOKEN
         run: |
-          e2e_api_token=aws secretsmanager get-secret-value --secret-id /prod/gh-actions/orchestrator-e2e-token --region us-west-2 | jq -r '.SecretString'
+          e2e_api_token=$(aws secretsmanager get-secret-value --secret-id /prod/gh-actions/orchestrator-e2e-token --region us-west-2 | jq -r '.SecretString')
           echo "::add-mask::${e2e_api_token}"
           echo "$TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -3,28 +3,50 @@ on:
     branches: [distribution-e2e-tests]
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      all-dists: ${{ steps.get-all-dists.outputs.dists }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-all-dists
+        name: Get build chunks
+        run: |
+          cd dist
+          echo "dists=$(ls -ld */* | grep ^d | awk '{print $9}' | jq -cnMR '[inputs | select(length>0)]')" >> $GITHUB_OUTPUT
   e2e:
     # We use this virtual environment because it supports nested virtualization.
     # See https://github.com/actions/virtual-environments/issues/433 for more
     # information
     runs-on: macos-12
+    needs:
+      - setup
+    strategy:
+      fail-fast: false
+      matrix: 
+        dist: ${{ fromJSON(needs.setup.outputs.all-dists) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache Vagrant boxes
+      - name: Cache Vagrant box
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('**/Vagrantfile') }}
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
           restore-keys: |
-            ${{ runner.os }}-vagrant-
+            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile')
 
-      - name: Test nested virtualization
+      - name: Run e2e
         run: |
-          cd ./dist/ubuntu/22.04
-          vagrant box update
-          vagrant up --provision
-          vagrant ssh -c "echo 'hello world!'"
-          vagrant destroy -f
+          cd ./dist/${{ matrix.dist }}
+          echo "Running ${{matrix.dist}}"
+
+      # - name: full e2e
+      #   run: |
+      #     cd ./dist/${{ matrix.dist }}
+      #     vagrant box update
+      #     vagrant up --provision
+      #     vagrant ssh -c "echo 'hello world!'"
+      #     vagrant destroy -f
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -20,7 +20,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vagrant-
 
-      - name: Vagrant base box update
+      - name: Test nested virtualization
         run: |
           cd ./dist/ubuntu/22.04
           vagrant box update

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -48,9 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('**/${{ matrix.dist }}/Vagrantfile') }}
-          restore-keys: |
-            ${{ runner.os }}-vagrant-${{ hashFiles('**/${{ matrix.dist }}/Vagrantfile') }}
+          key: ${{ runner.os }}-vagrant-${{ matrix.dist }}-${{ hashFiles('**/Vagrantfile') }}
 
       - name: Run e2e
         env:

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -53,17 +53,13 @@ jobs:
             ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
 
       - name: Run e2e
+        env:
+          DIST: ${{ matrix.dist }}
         run: |
           cd ./dist/${{ matrix.dist }}
-          echo "Running ${{matrix.dist}}"
-          echo "ENSURE MASKING $TEST_API_TOKEN"
-
-      # - name: full e2e
-      #   run: |
-      #     cd ./dist/${{ matrix.dist }}
-      #     vagrant box update
-      #     vagrant up --provision
-      #     vagrant upload ../../e2e.sh
-      #     vagrant ssh -c "echo 'hello world!'"
-      #     vagrant destroy -f
+          vagrant box update
+          vagrant up --provision
+          vagrant upload ../../e2e.sh
+          vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN echo 'Running e2e with DIST $DIST.'"
+          vagrant destroy -f
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::147803588724:role/github-actions-shared-dist-writer
+          role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2
 
       - name: Import e2e API TOKEN

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches: [distribution-e2e-tests]
-  
   schedule:
     - cron: '0 17 * * *' # every day at 5pm UTC
   

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches: [distribution-e2e-tests]
+
+jobs:
+  e2e:
+    # We use this virtual environment because it supports nested virtualization.
+    # See https://github.com/actions/virtual-environments/issues/433 for more
+    # information
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('**/Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+
+      - name: Vagrant base box update
+        run: vagrant box update
+
+      - name: Bring up the VM
+        run: |
+          cd ./dist/ubuntu/22.04
+          vagrant up --provision
+
+      - name: Run e2e
+        run: vagrant ssh -c "echo 'hello world!'"
+
+      - name: Destroy the VM
+        run: vagrant destroy -f

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,7 +1,10 @@
 on:
   push:
     branches: [distribution-e2e-tests]
-
+  
+  schedule:
+    - cron: '0 17 * * *' # every day at 5pm UTC
+  
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           e2e_api_token=$(aws secretsmanager get-secret-value --secret-id /prod/gh-actions/orchestrator-e2e-token --region us-west-2 | jq -r '.SecretString')
           echo "::add-mask::${e2e_api_token}"
-          echo "$TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
+          echo "TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
 
       - name: Cache Vagrant box
         uses: actions/cache@v3

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -21,11 +21,12 @@ jobs:
             ${{ runner.os }}-vagrant-
 
       - name: Vagrant base box update
-        run: vagrant box update
+        run: |
+          cd ./dist/ubuntu/22.04
+          vagrant box update
 
       - name: Bring up the VM
         run: |
-          cd ./dist/ubuntu/22.04
           vagrant up --provision
 
       - name: Run e2e

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -22,6 +22,7 @@ jobs:
     # See https://github.com/actions/virtual-environments/issues/433 for more
     # information
     runs-on: macos-12
+    timeout-minutes: 30 # If something hangs, timeout the job in 30 so we aren't billed for 6h * distributions * 10 (mac-os minute multiplier)
     needs:
       - setup
     permissions:
@@ -48,19 +49,31 @@ jobs:
           echo "TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
 
       - name: Cache Vagrant box
+        # Caches that are not accessed within the last week will be evicted
+        # If any or all of the vagrant files change a lot in a short period of time
+        # the cache may hit its 10GB limit at which point it will just start trimming
+        # cached items in order of oldest to newest. Worst case it will re-download a vagrant box
+        # (see https://github.com/actions/cache#cache-limits)
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ matrix.dist }}-${{ hashFiles('**/Vagrantfile') }}
+
+      - name: Provision e2e environment
+        run: |
+          cd ./dist/${{ matrix.dist }}
+          vagrant box update
+          vagrant up --provision
 
       - name: Run e2e
         env:
           DIST: ${{ matrix.dist }}
         run: |
           cd ./dist/${{ matrix.dist }}
-          vagrant box update
-          vagrant up --provision
           vagrant upload ../../e2e.sh
           vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN DIST=$DIST /bin/bash /home/vagrant/e2e.sh"
-          vagrant destroy -f
 
+      - name: Destroy e2e environment
+        run: |
+          cd ./dist/${{ matrix.dist }}
+          vagrant destroy -f

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -35,7 +35,7 @@ jobs:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
           restore-keys: |
-            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile')
+            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }} }}/Vagrantfile')
 
       - name: Run e2e
         run: |

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -35,7 +35,7 @@ jobs:
           path: ~/.vagrant.d/boxes
           key: ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
           restore-keys: |
-            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }} }}/Vagrantfile')
+            ${{ runner.os }}-vagrant-${{ hashFiles('dist/${{ matrix.dist }}/Vagrantfile') }}
 
       - name: Run e2e
         run: |

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -60,6 +60,6 @@ jobs:
           vagrant box update
           vagrant up --provision
           vagrant upload ../../e2e.sh
-          vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN echo 'Running e2e with DIST $DIST.'"
+          vagrant ssh -c "TEST_API_TOKEN=$TEST_API_TOKEN /bin/bash /home/vagrant/e2e.sh"
           vagrant destroy -f
 

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -24,13 +24,7 @@ jobs:
         run: |
           cd ./dist/ubuntu/22.04
           vagrant box update
-
-      - name: Bring up the VM
-        run: |
           vagrant up --provision
+          vagrant ssh -c "echo 'hello world!'"
+          vagrant destroy -f
 
-      - name: Run e2e
-        run: vagrant ssh -c "echo 'hello world!'"
-
-      - name: Destroy the VM
-        run: vagrant destroy -f

--- a/dist/amazon-linux/2/Vagrantfile
+++ b/dist/amazon-linux/2/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "4096"
-    vm.cpus = 1
+    vm.memory = "8192"
+    vm.cpus = 2
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"

--- a/dist/amazon-linux/2/Vagrantfile
+++ b/dist/amazon-linux/2/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "8192"
-    vm.cpus = 8
+    vm.memory = "4096"
+    vm.cpus = 1
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+#  This script is primarily intended to be used with the Vagrant definitions in each dist folder
+#  A monitor should be setup in the account for which $TEST_API_TOKEN belongs to (testsignal is a good option)
+#
+
+# Oddly enough even after yum remove or apt remove the orchestrator is still running. Clean that up
+StopAndDisableOrchestrator() {
+    sudo systemctl stop metrist-orchestrator
+    sudo systemctl disable metrist-orchestrator
+    sudo systemctl daemon-reload
+}
+
+RemoveOrchestrator(){
+    StopAndDisableOrchestrator
+
+    if type apt >/dev/null; then
+        sudo apt purge -y metrist-orchestrator
+    elif type yum >/dev/null; then
+        sudo yum remove -y metrist-orchestrator
+    fi
+}
+
+Main() {
+
+curl https://dist.metrist.io/install.sh >/tmp/install.sh
+
+cat <<EOF | bash /tmp/install.sh
+$TEST_API_TOKEN
+e2e_test_$DIST
+EOF
+
+# wait 45 seconds
+sleep 45
+
+success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
+
+if [ $success_count -gt 0 ]; then
+    RemoveOrchestrator
+    echo "e2e successful" 
+    exit 0
+else
+    RemoveOrchestrator
+    echo "Error during e2e, can't find 'All steps done'"
+    exit 1
+fi
+
+}
+
+Main

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -23,6 +23,9 @@ RemoveOrchestrator(){
 
 Main() {
 
+# Sanitize DIST env var before using it for instance id - remove forward slashes and periods
+DIST=${DIST//[\/\.]/}
+
 curl https://dist.metrist.io/install.sh >/tmp/install.sh
 
 cat <<EOF | bash /tmp/install.sh

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -33,12 +33,7 @@ $TEST_API_TOKEN
 e2e_test_$DIST
 EOF
 
-sudo journalctl -f -n 0 -u metrist-orchestrator.service &
-tail_pid=$!
-trap "sudo kill $tail_pid" INT TERM HUP QUIT EXIT # just in case this gets interrupted
-sleep 45
-sudo kill $tail_pid
-
+sudo journalctl --unit metrist-orchestrator --since "1m ago"
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 
 if [ $success_count -gt 0 ]; then

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -33,6 +33,8 @@ $TEST_API_TOKEN
 e2e_test_$DIST
 EOF
 
+sleep 45
+
 sudo journalctl --unit metrist-orchestrator --since "1m ago"
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -35,8 +35,9 @@ EOF
 
 sudo journalctl -f -n 0 -u metrist-orchestrator.service &
 tail_pid=$!
-trap "kill $tail_pid" INT TERM HUP QUIT EXIT
+trap "sudo kill $tail_pid" INT TERM HUP QUIT EXIT # just in case this gets interrupted
 sleep 45
+sudo kill $tail_pid
 
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -33,8 +33,10 @@ $TEST_API_TOKEN
 e2e_test_$DIST
 EOF
 
-# wait 45 seconds
+sudo journalctl -f -n 0 -u metrist-orchestrator.service &
+tail_pid=$!
 sleep 45
+kill $tail_pid
 
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -35,8 +35,9 @@ EOF
 
 sleep 45
 
-sudo journalctl --unit metrist-orchestrator --since "1m ago"
-success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
+logs=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" --no-pager)
+echo "$logs"
+success_count=$(echo "$logs" | grep -c "All steps done, asking monitor to exit")
 
 if [ $success_count -gt 0 ]; then
     RemoveOrchestrator

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -23,7 +23,7 @@ RemoveOrchestrator(){
 
 Main() {
 
-# Sanitize DIST env var before using it for instance id - remove forward slashes and periods
+# Sanitize DIST env var before using it for instance id - remove forward slashes, hyphens, and periods
 DIST=${DIST//[\/\.\-]/}
 
 curl https://dist.metrist.io/install.sh >/tmp/install.sh

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -24,7 +24,7 @@ RemoveOrchestrator(){
 Main() {
 
 # Sanitize DIST env var before using it for instance id - remove forward slashes and periods
-DIST=${DIST//[\/\.]/}
+DIST=${DIST//[\/\.\-]/}
 
 curl https://dist.metrist.io/install.sh >/tmp/install.sh
 

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -36,7 +36,7 @@ EOF
 sudo journalctl -f -n 0 -u metrist-orchestrator.service &
 tail_pid=$!
 sleep 45
-kill $tail_pid
+trap "kill $tail_pid" INT TERM HUP QUIT EXIT
 
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -35,11 +35,11 @@ EOF
 
 sleep 45
 
-logs=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" --no-pager)
-echo "$logs"
-success_count=$(echo "$logs" | grep -c "All steps done, asking monitor to exit")
+LOGS=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" --no-pager)
+echo "$LOGS"
+SUCCESS_COUNT=$(echo "$LOGS" | grep -c "All steps done, asking monitor to exit")
 
-if [ $success_count -gt 0 ]; then
+if [ $SUCCESS_COUNT -gt 0 ]; then
     RemoveOrchestrator
     echo "e2e successful" 
     exit 0

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -35,8 +35,8 @@ EOF
 
 sudo journalctl -f -n 0 -u metrist-orchestrator.service &
 tail_pid=$!
-sleep 45
 trap "kill $tail_pid" INT TERM HUP QUIT EXIT
+sleep 45
 
 success_count=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" | grep -c "All steps done, asking monitor to exit")
 

--- a/dist/interactive/install.sh
+++ b/dist/interactive/install.sh
@@ -287,7 +287,7 @@ InstallYum() {
     cd /tmp
     latest=$($CURL https://dist.metrist.io/orchestrator/$OS/$VERSION.$ARCH.latest.txt)
     $CURL "https://dist.metrist.io/orchestrator/$OS/$latest" >$latest
-    $SUDO yum localinstall ./$latest
+    $SUDO yum localinstall -y ./$latest
     cat <<EOF | $SUDO tee -a /etc/default/metrist-orchestrator >/dev/null
 
 # Added by installation script.

--- a/dist/ubuntu/20.04/Vagrantfile
+++ b/dist/ubuntu/20.04/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "4096"
-    vm.cpus = 1
+    vm.memory = "8192"
+    vm.cpus = 2
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"

--- a/dist/ubuntu/20.04/Vagrantfile
+++ b/dist/ubuntu/20.04/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "8192"
-    vm.cpus = 8
+    vm.memory = "4096"
+    vm.cpus = 1
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"

--- a/dist/ubuntu/22.04/Vagrantfile
+++ b/dist/ubuntu/22.04/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "4096"
-    vm.cpus = 1
+    vm.memory = "8192"
+    vm.cpus = 2
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"

--- a/dist/ubuntu/22.04/Vagrantfile
+++ b/dist/ubuntu/22.04/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure("2") do |config|
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|
-    vm.memory = "8192"
-    vm.cpus = 8
+    vm.memory = "4096"
+    vm.cpus = 1
     vm.memorybacking :access, :mode => "shared"
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"


### PR DESCRIPTION
Adds vagrant based e2e tests that run every day at 17:00 UTC via github actions.

1. Provisions the vagrant VM (done every time to ensure we have the latest packages)
2. Installs Orchestrator via our interactive install.sh script
3. Runs testsignal (dotnet DLL monitor) within 30s
4. Checks to ensure testsignal existed properly
5. Uninstalls/purges and stops the Orchestrator
6. Destroys the vagrant VM (clean slate next run)

Account that this sends telemetry to is `Orchestrator dist e2e`

There's a hard 30m timeout on the e2e job in case a parallel run gets stuck somehow (I have seen provisioning of the vagrant VM take 2m or 7m as an example on the same vagrant box)

Uses `macos-12` Github Action runner image as that is the only image that supports nested virtualization at the moment. Request to support it on Linux images have so far gone unanswered. See: https://github.com/actions/virtual-environments/issues/433

Reviewer can remove branch push trigger on the github action before merging. Left there for now so that the reviewer can trigger/try it.

```
  push:
    branches: [distribution-e2e-tests]
```

Deploy steps:

- [ ] Merge

Note: Secrets already setup

![image](https://user-images.githubusercontent.com/1853935/208201101-c34adfbe-cc7e-4086-94cb-09b20da837cd.png)

Internal reference: MET-1151
