### PR TITLE
MET-1159 Monitor/Instance not running alerting

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,4 +6,6 @@ config :orchestrator,
   api_token: System.get_env("METRIST_API_TOKEN"),
   instance_id: System.get_env("METRIST_INSTANCE_ID", "fake-dev-instance"),
   slack_api_token: System.get_env("SLACK_API_TOKEN"),
-  slack_reporting_channel: System.get_env("SLACK_ALERTING_CHANNEL")
+  slack_reporting_channel: System.get_env("SLACK_ALERTING_CHANNEL"),
+  monitor_running_alert_webhook_url: System.get_env("METRIST_MONITOR_RUNNING_ALERT_WEBHOOK_URL"),
+  monitor_running_alert_webhook_token: System.get_env("METRIST_MONITOR_RUNNING_ALERT_WEBHOOK_TOKEN")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,7 +7,9 @@ if config_env() == :prod do
     api_token: Orchestrator.Application.translate_config_from_env!("METRIST_API_TOKEN"),
     instance_id: Orchestrator.Application.translate_config_from_env!("METRIST_INSTANCE_ID"),
     slack_api_token: Orchestrator.Application.translate_config_from_env("SLACK_API_TOKEN"),
-    slack_reporting_channel: Orchestrator.Application.translate_config_from_env("SLACK_ALERTING_CHANNEL")
+    slack_reporting_channel: Orchestrator.Application.translate_config_from_env("SLACK_ALERTING_CHANNEL"),
+    monitor_running_alert_webhook_url: Orchestrator.Application.translate_config_from_env("METRIST_MONITOR_RUNNING_ALERT_WEBHOOK_URL"),
+    monitor_running_alert_webhook_token: Orchestrator.Application.translate_config_from_env("METRIST_MONITOR_RUNNING_ALERT_WEBHOOK_TOKEN")
 end
 
 # Erlexec has some protection against accidentally

--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -32,6 +32,9 @@ defmodule Orchestrator.Application do
         Orchestrator.HostTelemetry
       end,
       Metrist.Agent,
+      if Application.get_env(:orchestrator, :monitor_running_alert_webhook_url) do
+        Orchestrator.MonitorRunningAlerting
+      end,
       {Orchestrator.ConfigFetcher, [config_fetch_fun: config_fetch_fun]},
       {Task.Supervisor, name: Orchestrator.TaskSupervisor},
       Orchestrator.MonitorSupervisor,

--- a/lib/orchestrator/monitor_running_alerting.ex
+++ b/lib/orchestrator/monitor_running_alerting.ex
@@ -1,0 +1,123 @@
+defmodule Orchestrator.MonitorRunningAlerting do
+  use GenServer
+  require Logger
+
+  @timeout_threshold_seconds 5 * 60
+
+  defmodule State do
+    @type config_id :: String.t()
+    @type monitor_id :: String.t()
+    @type monitor_state :: :ok | :notrunning
+
+    @type t() :: %__MODULE__{
+      tracked_monitors: %{optional({config_id, monitor_id}) => {monitor_state, NaiveDateTime.t()}}
+    }
+
+    @enforce_keys [:tracked_monitors]
+    defstruct tracked_monitors: %{}
+  end
+
+  def start_link(args) do
+    name = Keyword.get(args, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, args, name: name)
+  end
+
+  def track_monitor(%{id: config_id, monitor_logical_name: monitor_id}) do
+    GenServer.cast(__MODULE__, {:track_monitor, config_id, monitor_id})
+  end
+
+  @spec untrack_monitor(%{:id => any, :monitor_logical_name => any, optional(any) => any}) :: :ok
+  def untrack_monitor(%{id: config_id, monitor_logical_name: monitor_id}) do
+    GenServer.cast(__MODULE__, {:untrack_monitor, config_id, monitor_id})
+  end
+
+  def update_monitor(%{id: config_id, monitor_logical_name: monitor_id}) do
+    GenServer.cast(__MODULE__, {:update_monitor, config_id, monitor_id})
+  end
+
+  @impl true
+  def init(_args) do
+    schedule_check()
+
+    {:ok, %State{tracked_monitors: %{}}}
+  end
+
+  @impl true
+  def handle_cast({:track_monitor, config_id, monitor_id}, state) do
+    tracked_monitors = Map.put_new(state.tracked_monitors, {config_id, monitor_id}, {:ok, NaiveDateTime.utc_now()})
+    {:noreply, %State{state | tracked_monitors: tracked_monitors} |> IO.inspect()}
+  end
+
+  def handle_cast({:untrack_monitor,config_id,  monitor_id}, state) do
+    tracked_monitors = Map.delete(state.tracked_monitors, {config_id, monitor_id})
+    {:noreply, %State{state | tracked_monitors: tracked_monitors}}
+  end
+
+  def handle_cast({:update_monitor, config_id, monitor_id}, state) do
+    tracked_monitors = case Map.get(state.tracked_monitors, {config_id, monitor_id}) do
+      nil ->
+        state.tracked_monitors
+      {monitor_state, _last_update_time} ->
+        Map.put(state.tracked_monitors, {config_id, monitor_id}, {monitor_state, NaiveDateTime.utc_now()})
+    end
+
+    {:noreply, %State{state | tracked_monitors: tracked_monitors}}
+  end
+
+  @impl true
+  def handle_info(:check_monitors, state) do
+    new_tracked_monitors = update_monitor_states(state.tracked_monitors)
+
+    get_changed_monitors(state.tracked_monitors, new_tracked_monitors)
+    |> send_alerts()
+
+    schedule_check()
+
+    {:noreply, %State{state | tracked_monitors: new_tracked_monitors}}
+  end
+
+  defp update_monitor_states(tracked_monitors) do
+    cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(), -@timeout_threshold_seconds)
+
+    Enum.map(tracked_monitors, fn {key, {_monitor_state, last_update_time}} ->
+      monitor_state = case NaiveDateTime.compare(last_update_time, cutoff) do
+        :lt -> :notrunning
+        _ -> :ok
+      end
+      {key, {monitor_state, last_update_time}}
+    end)
+    |> Map.new()
+  end
+
+  defp get_changed_monitors(old_tracked_monitors, new_tracked_monitors) do
+    Enum.filter(new_tracked_monitors, fn {key, {new_monitor_state, _last_update_time}} ->
+      case Map.get(old_tracked_monitors, key) do
+        {old_monitor_state, _} when new_monitor_state != old_monitor_state -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp send_alerts(changes) do
+    url = Application.get_env(:orchestrator, :monitor_running_alert_webhook_url)
+    token = Application.get_env(:orchestrator, :monitor_running_alert_webhook_token)
+    instance_id = Application.get_env(:orchestrator, :instance_id)
+
+    for {{config_id, monitor_id}, {monitor_state, last_update_time}} <- changes do
+      body = %{
+        config_id: config_id,
+        monitor_id: monitor_id,
+        instance_id: instance_id,
+        monitor_state: monitor_state,
+        last_update_time: NaiveDateTime.to_iso8601(last_update_time)
+      }
+      |> Jason.encode!()
+
+      HTTPoison.post(url, body, [{"Authorization", "Bearer #{token}"}, {"content-type", "application/json"}])
+    end
+  end
+
+  defp schedule_check(delay \\ 60_000) do
+    Process.send_after(self(), :check_monitors, delay)
+  end
+end

--- a/lib/orchestrator/monitor_running_alerting.ex
+++ b/lib/orchestrator/monitor_running_alerting.ex
@@ -94,7 +94,7 @@ defmodule Orchestrator.MonitorRunningAlerting do
     {:noreply, %State{state | tracked_monitors: new_tracked_monitors}}
   end
 
-  defp update_monitor_states(tracked_monitors) do
+  def update_monitor_states(tracked_monitors) do
     cutoff = NaiveDateTime.add(NaiveDateTime.utc_now(), -@timeout_threshold_seconds)
 
     Enum.map(tracked_monitors, fn {key, {_monitor_state, last_update_time}} ->
@@ -107,7 +107,7 @@ defmodule Orchestrator.MonitorRunningAlerting do
     |> Map.new()
   end
 
-  defp get_changed_monitors(old_tracked_monitors, new_tracked_monitors) do
+  def get_changed_monitors(old_tracked_monitors, new_tracked_monitors) do
     Enum.filter(new_tracked_monitors, fn {key, {new_monitor_state, _last_update_time}} ->
       case Map.get(old_tracked_monitors, key) do
         {old_monitor_state, _} when new_monitor_state != old_monitor_state -> true

--- a/test/orchestrator/monitor_running_alerting_test.exs
+++ b/test/orchestrator/monitor_running_alerting_test.exs
@@ -1,0 +1,68 @@
+defmodule Orchestrator.MonitorRunningAlertingTest do
+  use ExUnit.Case
+
+  @now NaiveDateTime.utc_now()
+  @one_hour_ago NaiveDateTime.add(@now, -3_600)
+
+  describe "update_monitor_states" do
+    test "Should mark ok monitors with no recent data as notrunning" do
+      tracked_monitors = %{{"config", "monitor"} => {:ok, @one_hour_ago}}
+      updated_monitors = Orchestrator.MonitorRunningAlerting.update_monitor_states(tracked_monitors)
+
+      assert Map.get(updated_monitors, {"config", "monitor"}) == {:notrunning, @one_hour_ago}
+    end
+
+    test "Should mark notrunning monitors withrecent data as ok" do
+      tracked_monitors = %{{"config", "monitor"} => {:notrunning, @now}}
+      updated_monitors = Orchestrator.MonitorRunningAlerting.update_monitor_states(tracked_monitors)
+
+      assert Map.get(updated_monitors, {"config", "monitor"}) == {:ok, @now}
+    end
+
+    test "Should not change ok monitors with recent data" do
+      tracked_monitors = %{{"config", "monitor"} => {:ok, @now}}
+      updated_monitors = Orchestrator.MonitorRunningAlerting.update_monitor_states(tracked_monitors)
+
+      assert Map.get(updated_monitors, {"config", "monitor"}) == {:ok, @now}
+    end
+
+    test "Should not change notrunning monitors with no recent data" do
+      tracked_monitors = %{{"config", "monitor"} => {:notrunning, @one_hour_ago}}
+      updated_monitors = Orchestrator.MonitorRunningAlerting.update_monitor_states(tracked_monitors)
+
+      assert Map.get(updated_monitors, {"config", "monitor"}) == {:notrunning, @one_hour_ago}
+    end
+  end
+
+  describe "get_changed_monitors" do
+    test "should return a list of monitors with changed state" do
+      old_monitors = %{
+        {"config1", "monitor1"} => {:notrunning, @one_hour_ago},
+        {"config2", "monitor2"} => {:ok, @now},
+      }
+      new_monitors = %{
+        {"config1", "monitor1"} => {:ok, @now},
+        {"config2", "monitor2"} => {:ok, @now}
+      }
+
+      changes = Orchestrator.MonitorRunningAlerting.get_changed_monitors(old_monitors, new_monitors)
+
+      assert changes == [{{"config1", "monitor1"}, {:ok, @now}}]
+    end
+
+    test "should return an empty list when no changes" do
+      old_monitors = %{
+        {"config1", "monitor1"} => {:notrunning, @one_hour_ago},
+        {"config2", "monitor2"} => {:ok, @now},
+      }
+      new_monitors = %{
+        {"config1", "monitor1"} => {:notrunning, @one_hour_ago},
+        {"config2", "monitor2"} => {:ok, @now}
+      }
+
+      changes = Orchestrator.MonitorRunningAlerting.get_changed_monitors(old_monitors, new_monitors)
+
+      assert changes == []
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adds a genserver that tracks recent activity for monitors, hooked into the scheduler. Will send a POST to a configured webhook endpoint if no activity measured for > 5 minutes

### Deployment Steps
- [ ] Merge