### PR TITLE
MET-1175 Add support for CentOS Linux 7 to interactive install script

### DIFF
--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron: '0 17 * * *' # every day at 5pm UTC
+  push:
+  # schedule:
+  #   - cron: '0 17 * * *' # every day at 5pm UTC
 
 jobs:
   setup:

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-  # schedule:
-  #   - cron: '0 17 * * *' # every day at 5pm UTC
+  schedule:
+    - cron: '0 17 * * *' # every day at 5pm UTC
 
 jobs:
   setup:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'amazon_linux-2']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'amazon_linux-2', 'rocky-8', 'centos-7']
     permissions:
       id-token: write
       contents: read

--- a/dist/centos/7/Dockerfile
+++ b/dist/centos/7/Dockerfile
@@ -1,0 +1,46 @@
+FROM centos:centos7 AS build
+
+ENV REFRESHED_AT 20230111T153816Z
+# Using en_US.UTF-8 since C.UTF-8 not available in centos7
+ENV LANG=en_US.UTF-8
+ENV MIX_ENV=prod
+
+ENV ERLANG_VERSION 25.1.1
+ENV ELIXIR_VERSION 1.14.1
+
+RUN yum -y update
+
+RUN yum install -y git openssl-devel ncurses-devel wget && \
+    yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory && \
+    yum clean -y all && rm -rf /var/cache/yum
+
+RUN cd /tmp && \
+  wget "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.gz" -O ruby.tar.gz && \
+  mkdir ruby && \
+  tar -xzf ruby.tar.gz -C ruby --strip-component=1 && \
+  cd ruby && \
+  ./configure && make && make install && rm -rf /tmp/ruby*
+
+RUN gem install fpm
+
+RUN cd /tmp && \
+  wget "https://github.com/erlang/otp/releases/download/OTP-$ERLANG_VERSION/otp_src_$ERLANG_VERSION.tar.gz" -O otp.tar.gz && \
+  mkdir otp && \
+  tar -xzf otp.tar.gz -C otp --strip-components=1 && \
+  cd otp && \
+  ./configure && make && make install && rm -rf /tmp/otp*
+
+RUN cd /tmp && \
+  wget "https://github.com/elixir-lang/elixir/archive/v$ELIXIR_VERSION.tar.gz" -O elixir.tar.gz && \
+  mkdir elixir && \
+  tar -xzf elixir.tar.gz -C elixir --strip-components=1 && \
+  cd elixir && \
+  make && make install && rm -rf /tmp/elixir*
+
+WORKDIR /app
+
+# We run under a UID with no HOME set so make sure that
+# our tooling can write to where we need.
+RUN mkdir /.mix && chmod 777 /.mix
+RUN mkdir /.hex && chmod 777 /.hex
+RUN mkdir /.cache && chmod 777 /.cache

--- a/dist/centos/7/Vagrantfile
+++ b/dist/centos/7/Vagrantfile
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# -*- mode: ruby -*-
+#
+#  This Vagrantfile is provided to make testing on a certain distribution easier.
+#  See https://developer.hashicorp.com/vagrant/docs/installation for instructions.
+#
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
+  # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
+  # commercial use we need to sort out first.
+  config.vm.provider "libvirt" do |vm|
+    vm.memory = "8192"
+    vm.cpus = 2
+    vm.memorybacking :access, :mode => "shared"
+  end
+  config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    # Basic stuff
+    yum update
+    yum install -y curl sudo zstd git curl unzip wget
+
+    # Quality-of-life tweaks to login shells go here
+    cat >>/home/vagrant/.profile <<EOF
+ulimit -n 1048576
+EOF
+  SHELL
+end

--- a/dist/centos/7/after-remove.sh
+++ b/dist/centos/7/after-remove.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+SERVICE="metrist-orchestrator.service"
+
+if systemctl is-enabled --quiet $SERVICE; then
+  systemctl stop $SERVICE
+  systemctl disable $SERVICE
+  systemctl reset-failed $SERVICE
+  systemctl daemon-reload
+fi

--- a/dist/centos/7/fpm.cmd
+++ b/dist/centos/7/fpm.cmd
@@ -1,0 +1,1 @@
+-t rpm -d procps-ng -d glibc -d ncurses -d openssl-devel -d libgcc -d libstdc++ -d lksctp-tools

--- a/dist/centos/7/inc/etc/default/metrist-orchestrator
+++ b/dist/centos/7/inc/etc/default/metrist-orchestrator
@@ -1,0 +1,14 @@
+# Environment variables for Metrist Orchestrator.
+#
+# This file serves as documentation only, the official way to
+# override/change these is to edit with `systemctl edit metrist-orchestrator`
+#
+
+# Either HOME or this variable needs to be set
+BAKEWARE_CACHE=/tmp/.metrist-bwcache
+
+# We want a UTF-8 based locale. The "C" locale is always
+# available.
+LC_LANG=C.UTF-8
+
+# TODO: add actual variables to be set.

--- a/dist/centos/7/inc/etc/systemd/system/metrist-orchestrator.service
+++ b/dist/centos/7/inc/etc/systemd/system/metrist-orchestrator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Metrist.io Orchestrator service
+
+[Service]
+User=%u
+ExecStartPre=/usr/bin/mkdir -p /run/metrist-orchestrator
+ExecStart=/usr/bin/metrist-orchestrator
+EnvironmentFile=-/etc/default/metrist-orchestrator
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/interactive/install.sh
+++ b/dist/interactive/install.sh
@@ -204,6 +204,11 @@ DetectOS() {
                 ExitWithUnsupportedOS
             fi
             ;;
+        centos)
+            if [ "$VERSION" != "7" ]; then
+                ExitWithUnsupportedOS
+            fi
+            ;;
         *)
             ExitWithUnsupportedOS
     esac

--- a/dist/rocky/8/Vagrantfile
+++ b/dist/rocky/8/Vagrantfile
@@ -16,8 +16,6 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"
 
   config.vm.provision "shell", inline: <<-SHELL
-    DEBIAN_FRONTEND=noninteractive
-
     # Basic stuff
     dnf update
     dnf install -y curl sudo zstd git curl unzip wget


### PR DESCRIPTION
Enables centos7 in the install script and adds building + e2e testing
Adds centos7 (and rocky8 which was missed in previous pr) to list built in main workflow