### PR TITLE
MET-1183 Add support for RedHat 7.9 to interactive install script

### DIFF
--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -46,6 +46,10 @@ jobs:
           echo "::add-mask::${e2e_api_token}"
           echo "TEST_API_TOKEN=${e2e_api_token}" >> $GITHUB_ENV
 
+      - name: Enable vagrant-registration for rhel
+        if: ${{ startsWith(matrix.dist, 'rhel') }}
+        run: vagrant plugin install vagrant-registration
+
       - name: Cache Vagrant box
         # Caches that are not accessed within the last week will be evicted
         # If any or all of the vagrant files change a lot in a short period of time
@@ -58,6 +62,9 @@ jobs:
           key: ${{ runner.os }}-vagrant-${{ matrix.dist }}-${{ hashFiles('**/Vagrantfile') }}
 
       - name: Provision e2e environment
+        env:
+          RHEL_USERNAME: ${{ secrets.RHEL_USERNAME }}
+          RHEL_PASSWORD: ${{ secrets.RHEL_PASSWORD }}
         run: |
           cd ./dist/${{ matrix.dist }}
           vagrant box update

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,6 +1,7 @@
 on:
-  schedule:
-    - cron: '0 17 * * *' # every day at 5pm UTC
+  push:
+  # schedule:
+  #   - cron: '0 17 * * *' # every day at 5pm UTC
 
 jobs:
   setup:

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -29,7 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: ${{ fromJSON(needs.setup.outputs.all-dists) }}
+        dist: ['rhel/7']
+        # dist: ${{ fromJSON(needs.setup.outputs.all-dists) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-  # schedule:
-  #   - cron: '0 17 * * *' # every day at 5pm UTC
+  schedule:
+    - cron: '0 17 * * *' # every day at 5pm UTC
 
 jobs:
   setup:
@@ -29,8 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dist: ['rhel/7']
-        # dist: ${{ fromJSON(needs.setup.outputs.all-dists) }}
+        dist: ${{ fromJSON(needs.setup.outputs.all-dists) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'amazon_linux-2', 'rocky-8', 'centos-7']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'amazon_linux-2', 'rocky-8', 'centos-7', 'rhel-7']
     permissions:
       id-token: write
       contents: read

--- a/dist/do-build.sh
+++ b/dist/do-build.sh
@@ -44,7 +44,8 @@ cp _build/prod/rel/bakeware/orchestrator $dest/usr/bin/metrist-orchestrator
 # Build the package. Distribution-method specific arguments MUST
 # be in the `fpm.cmd` file in the rel directory. At a minimum, this
 # should contain something like "-t deb"
-cd $dest
+mkdir /tmp/fpm
+
 fpm --verbose -s dir \
     $(cat $rel/fpm.cmd) \
     --after-remove $rel/after-remove.sh \
@@ -56,6 +57,8 @@ fpm --verbose -s dir \
     -v $orch_ver-$dist-$ver-$tag \
     -a native \
     -p $pkg_dest \
+    -C $dest \
+    --workdir /tmp/fpm \
     .
 
 pkg=$(cd $pkg_dest; ls)

--- a/dist/interactive/install.sh
+++ b/dist/interactive/install.sh
@@ -121,6 +121,9 @@ DetectOS() {
                 OS="$ID"
                 VERSION="$(echo "$VERSION_ID" | cut -f1 -d.)"
                 PACKAGETYPE="dnf"
+                if [ "$VERSION" = "7" ]; then
+                    PACKAGETYPE="yum"
+                fi
                 ;;
             fedora)
                 OS="$ID"
@@ -205,6 +208,11 @@ DetectOS() {
             fi
             ;;
         centos)
+            if [ "$VERSION" != "7" ]; then
+                ExitWithUnsupportedOS
+            fi
+            ;;
+        rhel)
             if [ "$VERSION" != "7" ]; then
                 ExitWithUnsupportedOS
             fi

--- a/dist/rhel/7/Dockerfile
+++ b/dist/rhel/7/Dockerfile
@@ -1,0 +1,43 @@
+FROM registry.access.redhat.com/ubi7/ruby-27 AS build
+
+USER root
+
+ENV REFRESHED_AT 20230111T153816Z
+# Using en_US.UTF-8 since C.UTF-8 not available in rhel
+ENV LANG=en_US.UTF-8
+ENV MIX_ENV=prod
+
+ENV ERLANG_VERSION 25.1.1
+ENV ELIXIR_VERSION 1.14.1
+
+RUN yum install -y --disableplugin=subscription-manager git gcc openssl-devel ncurses-devel wget rpmdevtools rpmlint && \
+    yum clean -y all && rm -rf /var/cache/yum
+
+COPY bin/rpmdevtools-8.3-7.el7.noarch.rpm /tmp
+
+USER default
+
+RUN gem install fpm
+
+RUN cd /tmp && \
+  wget "https://github.com/erlang/otp/releases/download/OTP-$ERLANG_VERSION/otp_src_$ERLANG_VERSION.tar.gz" -O otp.tar.gz && \
+  mkdir otp && \
+  tar -xzf otp.tar.gz -C otp --strip-components=1 && \
+  cd otp && \
+  ./configure && make && make install && rm -rf /tmp/otp*
+
+RUN cd /tmp && \
+  wget "https://github.com/elixir-lang/elixir/archive/v$ELIXIR_VERSION.tar.gz" -O elixir.tar.gz && \
+  mkdir elixir && \
+  tar -xzf elixir.tar.gz -C elixir --strip-components=1 && \
+  cd elixir && \
+  make && make install && rm -rf /tmp/elixir*
+
+WORKDIR /app
+
+# We run under a UID with no HOME set so make sure that
+# our tooling can write to where we need.
+RUN mkdir /.mix && chmod 777 /.mix
+RUN mkdir /.hex && chmod 777 /.hex
+RUN mkdir /.cache && chmod 777 /.cache
+

--- a/dist/rhel/7/Dockerfile
+++ b/dist/rhel/7/Dockerfile
@@ -1,21 +1,68 @@
-FROM registry.access.redhat.com/ubi7/ruby-27 AS build
+# FROM registry.access.redhat.com/ubi7/ruby-27 AS build
 
-USER root
+# USER root
+
+# ENV REFRESHED_AT 20230111T153816Z
+# # Using en_US.UTF-8 since C.UTF-8 not available in rhel
+# ENV LANG=en_US.UTF-8
+# ENV MIX_ENV=prod
+
+# ENV ERLANG_VERSION 25.1.1
+# ENV ELIXIR_VERSION 1.14.1
+
+# RUN yum install -y --disableplugin=subscription-manager git gcc openssl-devel ncurses-devel wget rpmdevtools rpmlint && \
+#     yum clean -y all && rm -rf /var/cache/yum
+
+# COPY bin/rpmdevtools-8.3-7.el7.noarch.rpm /tmp
+
+# USER default
+
+# RUN gem install fpm
+
+# RUN cd /tmp && \
+#   wget "https://github.com/erlang/otp/releases/download/OTP-$ERLANG_VERSION/otp_src_$ERLANG_VERSION.tar.gz" -O otp.tar.gz && \
+#   mkdir otp && \
+#   tar -xzf otp.tar.gz -C otp --strip-components=1 && \
+#   cd otp && \
+#   ./configure && make && make install && rm -rf /tmp/otp*
+
+# RUN cd /tmp && \
+#   wget "https://github.com/elixir-lang/elixir/archive/v$ELIXIR_VERSION.tar.gz" -O elixir.tar.gz && \
+#   mkdir elixir && \
+#   tar -xzf elixir.tar.gz -C elixir --strip-components=1 && \
+#   cd elixir && \
+#   make && make install && rm -rf /tmp/elixir*
+
+# WORKDIR /app
+
+# # We run under a UID with no HOME set so make sure that
+# # our tooling can write to where we need.
+# RUN mkdir /.mix && chmod 777 /.mix
+# RUN mkdir /.hex && chmod 777 /.hex
+# RUN mkdir /.cache && chmod 777 /.cache
+
+FROM centos:centos7 AS build
 
 ENV REFRESHED_AT 20230111T153816Z
-# Using en_US.UTF-8 since C.UTF-8 not available in rhel
+# Using en_US.UTF-8 since C.UTF-8 not available in centos7
 ENV LANG=en_US.UTF-8
 ENV MIX_ENV=prod
 
 ENV ERLANG_VERSION 25.1.1
 ENV ELIXIR_VERSION 1.14.1
 
-RUN yum install -y --disableplugin=subscription-manager git gcc openssl-devel ncurses-devel wget rpmdevtools rpmlint && \
+RUN yum -y update
+
+RUN yum install -y git openssl-devel ncurses-devel wget && \
+    yum groupinstall -y "Development Tools" --setopt=group_package_types=mandatory && \
     yum clean -y all && rm -rf /var/cache/yum
 
-COPY bin/rpmdevtools-8.3-7.el7.noarch.rpm /tmp
-
-USER default
+RUN cd /tmp && \
+  wget "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.gz" -O ruby.tar.gz && \
+  mkdir ruby && \
+  tar -xzf ruby.tar.gz -C ruby --strip-component=1 && \
+  cd ruby && \
+  ./configure && make && make install && rm -rf /tmp/ruby*
 
 RUN gem install fpm
 
@@ -40,4 +87,3 @@ WORKDIR /app
 RUN mkdir /.mix && chmod 777 /.mix
 RUN mkdir /.hex && chmod 777 /.hex
 RUN mkdir /.cache && chmod 777 /.cache
-

--- a/dist/rhel/7/Dockerfile
+++ b/dist/rhel/7/Dockerfile
@@ -1,46 +1,6 @@
-# FROM registry.access.redhat.com/ubi7/ruby-27 AS build
-
-# USER root
-
-# ENV REFRESHED_AT 20230111T153816Z
-# # Using en_US.UTF-8 since C.UTF-8 not available in rhel
-# ENV LANG=en_US.UTF-8
-# ENV MIX_ENV=prod
-
-# ENV ERLANG_VERSION 25.1.1
-# ENV ELIXIR_VERSION 1.14.1
-
-# RUN yum install -y --disableplugin=subscription-manager git gcc openssl-devel ncurses-devel wget rpmdevtools rpmlint && \
-#     yum clean -y all && rm -rf /var/cache/yum
-
-# COPY bin/rpmdevtools-8.3-7.el7.noarch.rpm /tmp
-
-# USER default
-
-# RUN gem install fpm
-
-# RUN cd /tmp && \
-#   wget "https://github.com/erlang/otp/releases/download/OTP-$ERLANG_VERSION/otp_src_$ERLANG_VERSION.tar.gz" -O otp.tar.gz && \
-#   mkdir otp && \
-#   tar -xzf otp.tar.gz -C otp --strip-components=1 && \
-#   cd otp && \
-#   ./configure && make && make install && rm -rf /tmp/otp*
-
-# RUN cd /tmp && \
-#   wget "https://github.com/elixir-lang/elixir/archive/v$ELIXIR_VERSION.tar.gz" -O elixir.tar.gz && \
-#   mkdir elixir && \
-#   tar -xzf elixir.tar.gz -C elixir --strip-components=1 && \
-#   cd elixir && \
-#   make && make install && rm -rf /tmp/elixir*
-
-# WORKDIR /app
-
-# # We run under a UID with no HOME set so make sure that
-# # our tooling can write to where we need.
-# RUN mkdir /.mix && chmod 777 /.mix
-# RUN mkdir /.hex && chmod 777 /.hex
-# RUN mkdir /.cache && chmod 777 /.cache
-
+# Copied from the CentOS 7 dockerfile. RedHat requires a subscription set up to
+# install all the necessary packages, and docker has issues authenticating it.
+# So instead, we simply build the rpm in CentOS 7.
 FROM centos:centos7 AS build
 
 ENV REFRESHED_AT 20230111T153816Z

--- a/dist/rhel/7/Vagrantfile
+++ b/dist/rhel/7/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     # Basic stuff
     yum update
-    yum install -y curl sudo zstd git curl unzip wget openssl lksctp-tools
+    yum install -y curl sudo zstd git curl unzip wget
 
     # Quality-of-life tweaks to login shells go here
     cat >>/home/vagrant/.profile <<EOF

--- a/dist/rhel/7/Vagrantfile
+++ b/dist/rhel/7/Vagrantfile
@@ -15,10 +15,15 @@ Vagrant.configure("2") do |config|
   end
   config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"
 
+  if Vagrant.has_plugin?('vagrant-registration')
+    config.registration.username = ENV['RHEL_USERNAME']
+    config.registration.password = ENV['RHEL_PASSWORD']
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
     # Basic stuff
     yum update
-    yum install -y curl sudo zstd git curl unzip wget
+    yum install -y curl sudo zstd git curl unzip wget openssl lksctp-tools
 
     # Quality-of-life tweaks to login shells go here
     cat >>/home/vagrant/.profile <<EOF

--- a/dist/rhel/7/Vagrantfile
+++ b/dist/rhel/7/Vagrantfile
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+# -*- mode: ruby -*-
+#
+#  This Vagrantfile is provided to make testing on a certain distribution easier.
+#  See https://developer.hashicorp.com/vagrant/docs/installation for instructions.
+#
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/rhel7"
+  # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
+  # commercial use we need to sort out first.
+  config.vm.provider "libvirt" do |vm|
+    vm.memory = "8192"
+    vm.cpus = 2
+    vm.memorybacking :access, :mode => "shared"
+  end
+  config.vm.synced_folder "../../../", "/vagrant" #, type: "virtiofs"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    # Basic stuff
+    yum update
+    yum install -y curl sudo zstd git curl unzip wget
+
+    # Quality-of-life tweaks to login shells go here
+    cat >>/home/vagrant/.profile <<EOF
+ulimit -n 1048576
+EOF
+  SHELL
+end

--- a/dist/rhel/7/after-remove.sh
+++ b/dist/rhel/7/after-remove.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+SERVICE="metrist-orchestrator.service"
+
+systemctl daemon-reload
+systemctl stop $SERVICE

--- a/dist/rhel/7/fpm.cmd
+++ b/dist/rhel/7/fpm.cmd
@@ -1,1 +1,1 @@
--t rpm -d procps-ng -d glibc -d ncurses -d openssl-devel -d libgcc -d libstdc++ -d lksctp-tools
+-t rpm -d procps-ng -d glibc -d ncurses -d openssl -d libgcc -d libstdc++ -d lksctp-tools

--- a/dist/rhel/7/fpm.cmd
+++ b/dist/rhel/7/fpm.cmd
@@ -1,0 +1,1 @@
+-t rpm -d procps-ng -d glibc -d ncurses -d openssl-devel -d libgcc -d libstdc++ -d lksctp-tools

--- a/dist/rhel/7/fpm.cmd
+++ b/dist/rhel/7/fpm.cmd
@@ -1,1 +1,1 @@
--t rpm -d procps-ng -d glibc -d ncurses -d openssl -d libgcc -d libstdc++ -d lksctp-tools
+-t rpm -d procps-ng -d glibc -d ncurses -d openssl -d libgcc -d libstdc++ -d lksctp-tools -d libicu

--- a/dist/rhel/7/inc/etc/default/metrist-orchestrator
+++ b/dist/rhel/7/inc/etc/default/metrist-orchestrator
@@ -1,0 +1,14 @@
+# Environment variables for Metrist Orchestrator.
+#
+# This file serves as documentation only, the official way to
+# override/change these is to edit with `systemctl edit metrist-orchestrator`
+#
+
+# Either HOME or this variable needs to be set
+BAKEWARE_CACHE=/tmp/.metrist-bwcache
+
+# We want a UTF-8 based locale. The "C" locale is always
+# available.
+LC_LANG=C.UTF-8
+
+# TODO: add actual variables to be set.

--- a/dist/rhel/7/inc/etc/systemd/system/metrist-orchestrator.service
+++ b/dist/rhel/7/inc/etc/systemd/system/metrist-orchestrator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Metrist.io Orchestrator service
+
+[Service]
+User=%u
+ExecStartPre=/usr/bin/mkdir -p /run/metrist-orchestrator
+ExecStart=/usr/bin/metrist-orchestrator
+EnvironmentFile=-/etc/default/metrist-orchestrator
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Enables rhel7 in the install script and adds building + e2e testing. Uses CentOS 7 docker image to build the rpm due to issues authenticating the subscription on docker, which was required to install certain dev packages