### PR TITLE
MET-1192 Ensure all processes related to a monitor run are cleaned up

### DIFF
--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -62,7 +62,7 @@ defmodule Orchestrator.Invoker do
     # On the protocol level, we don't care too much about process exit states, so the
     # easiest work-around is to have a success exit code that will trigger the linked error
     # exit.
-    opts = opts ++ [:stdin, :stdout, :stderr, :monitor, success_exit_code: 1]
+    opts = opts ++ [:stdin, :stdout, :stderr, :monitor, :kill_group, success_exit_code: 1, group: 0]
 
     {:ok, _pid, os_pid} = :exec.run_link(cmd_line, opts)
     os_pid

--- a/lib/orchestrator/monitor_running_alerting.ex
+++ b/lib/orchestrator/monitor_running_alerting.ex
@@ -63,7 +63,7 @@ defmodule Orchestrator.MonitorRunningAlerting do
   @impl true
   def handle_cast({:track_monitor, config_id, monitor_id}, state) do
     tracked_monitors = Map.put_new(state.tracked_monitors, {config_id, monitor_id}, {:ok, NaiveDateTime.utc_now()})
-    {:noreply, %State{state | tracked_monitors: tracked_monitors} |> IO.inspect()}
+    {:noreply, %State{state | tracked_monitors: tracked_monitors}}
   end
 
   def handle_cast({:untrack_monitor,config_id,  monitor_id}, state) do


### PR DESCRIPTION
Triggered by orphaned chromium processes from the New Relic ui checks, this will make the orchestrator spawn monitor processes in their own groups which, with the `:kill_group` option, will ensure the entire group is killed once the main process exits.