### PR TITLE
MET-1194 Make orchestrator refresh configs

### DIFF
--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -133,6 +133,7 @@ else
   end
 end
 
+  @spec translate_config_from_env(binary, any) :: any
   def translate_config_from_env(env, default \\ nil) do
     case System.get_env(env) do
       nil ->

--- a/lib/orchestrator/config_fetcher.ex
+++ b/lib/orchestrator/config_fetcher.ex
@@ -3,8 +3,6 @@ defmodule Orchestrator.ConfigFetcher do
   This process fetches the configuration every minute and compares it with the current state. If anything
   changes, it'll forward the diffs to the process that supervises all the monitors so it can make
   adjustments.
-
-  Every `@clean_fetch_interval_ms` it will drop the old configuration
   """
   use GenServer
   require Logger

--- a/lib/orchestrator/config_fetcher.ex
+++ b/lib/orchestrator/config_fetcher.ex
@@ -3,6 +3,8 @@ defmodule Orchestrator.ConfigFetcher do
   This process fetches the configuration every minute and compares it with the current state. If anything
   changes, it'll forward the diffs to the process that supervises all the monitors so it can make
   adjustments.
+
+  Every `@clean_fetch_interval_ms` it will drop the old configuration
   """
   use GenServer
   require Logger

--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -85,6 +85,35 @@ defmodule Orchestrator.Configuration do
     |> store_configs
   end
 
+  @doc """
+  For logging, use this function to obfuscate the extra config as that may hold secrets. Basically we print the
+  first and last three characters of values; we don't expect secrets to be so short that this would leak a significant amount
+  of data. It's a security/convenience trade-off.
+  """
+  @spec redact(%{:extra_config => any, optional(any) => any}) :: %{
+          :extra_config => nil | map,
+          optional(any) => any
+        }
+  def redact(monitor_config) do
+    Map.put(monitor_config, :extra_config, do_redact(monitor_config.extra_config))
+  end
+  defp do_redact(nil), do: nil
+  defp do_redact(extra_config) do
+    extra_config
+    |> Enum.map(fn
+      {k, nil} ->
+        # Yes, this will probably log the same thing more often than once, but better that then never for now.
+        Logger.error("Unexpected nil value in extra config under key #{k} found during redaction, monitor may not work!")
+        {k, nil}
+      {k, e = << "<<ERROR:", _rest::binary>>} ->
+        # "<<ERROR: error message>>" is generated during `translate_value/1`, let's keep these in the clear
+        {k, e}
+      {k, v} ->
+        {k, String.replace(v, ~r/(...).+(...)/, "\\1..\\2")}
+    end)
+    |> Map.new()
+  end
+
   defp find_added(new_config, old_config) do
     new_list = Map.get(new_config, :monitors, [])
     old_list = Map.get(old_config, :monitors, [])

--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -50,7 +50,10 @@ defmodule Orchestrator.Configuration do
 
   @doc """
   Retrieve a config by its unique id. The config is retrieved from the ETS table that
-  contains all monitor configurations we know about.
+  contains all monitor configurations we know about. We translate only at this point
+  so we get the freshest values of both secrets and environment variables (the latter,
+  of course, are as of yet static but making that somehow dynamically settable would then
+  "just work").
   """
   @spec get_config(String.t()) :: map()
   def get_config(name) do

--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -52,6 +52,7 @@ defmodule Orchestrator.Configuration do
   Retrieve a config by its unique id. The config is retrieved from the ETS table that
   contains all monitor configurations we know about.
   """
+  @spec get_config(String.t()) :: map()
   def get_config(name) do
     case :ets.lookup(__MODULE__, name) do
       [{_name, config}] ->

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -30,7 +30,7 @@ defmodule Orchestrator.Invoker do
       Process.flag(:trap_exit, true)
 
       os_pid = start_function.(tmpdir)
-      GenServer.cast(parent, {:monitor_pid, os_pid})
+      Orchestrator.MonitorScheduler.set_monitor_os_pid(parent, os_pid)
 
       Logger.info("Started monitor with OS pid #{os_pid}")
       Logger.metadata(os_pid: os_pid)

--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -13,7 +13,7 @@ defmodule Orchestrator.MonitorScheduler do
 
   # How often we force re-reading configuration. This is mostly to ensure that
   # changes in secrets propagate.
-  @config_refresh_interval_ms :timer.minutes(60)
+  @config_refresh_interval_ms :timer.minutes(10)
 
   # A long, long time ago. Epoch of the modified Julian Date
   @never "1858-11-07 00:00:00"

--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -112,7 +112,6 @@ defmodule Orchestrator.MonitorScheduler do
 
   # Run a monitor. This depends on the "run type" configured, which can be any of the
   # options handled in the function heads below.
-
   defp do_run(cfg = %{run_spec: %{run_type: "dll"}}) do
     opts = [error_report_fun: get_monitor_error_handler("dll")]
     Orchestrator.DotNetDLLInvoker.invoke(cfg, opts)

--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -137,7 +137,7 @@ defmodule Orchestrator.MonitorScheduler do
     Orchestrator.LambdaInvoker.invoke(cfg, opts)
   end
   defp do_run(cfg = %{run_spec: %{run_type: _}}) do
-    Logger.warn("Unknown run specification in config: #{inspect Orchestrator.MonitorSupervisor.redact(cfg)}")
+    Logger.warn("Unknown run specification in config: #{inspect Configuration.redact(cfg)}")
     Task.async(fn -> :ok end)
   end
   defp do_run(cfg) do

--- a/lib/orchestrator/monitor_scheduler.ex
+++ b/lib/orchestrator/monitor_scheduler.ex
@@ -13,7 +13,7 @@ defmodule Orchestrator.MonitorScheduler do
 
   # How often we force re-reading configuration. This is mostly to ensure that
   # changes in secrets propagate.
-  @config_refresh_interval_ms :timer.minutes(10)
+  @config_refresh_interval_ms :timer.minutes(60)
 
   # A long, long time ago. Epoch of the modified Julian Date
   @never "1858-11-07 00:00:00"

--- a/lib/orchestrator/monitor_supervisor.ex
+++ b/lib/orchestrator/monitor_supervisor.ex
@@ -25,7 +25,6 @@ defmodule Orchestrator.MonitorSupervisor do
   def process_deltas(supervisor_name, deltas) do
     stop_deleted(supervisor_name, deltas.delete)
     start_added(supervisor_name, deltas.add)
-    update_changed(supervisor_name, deltas.change)
   end
 
   defp stop_deleted(supervisor_name, monitor_configs) do
@@ -56,13 +55,4 @@ defmodule Orchestrator.MonitorSupervisor do
       end
     end)
   end
-
-  defp update_changed(supervisor_name, monitor_configs) do
-    Enum.map(monitor_configs, fn monitor_config ->
-      name = child_name(supervisor_name, Configuration.unique_key(monitor_config))
-      Logger.info("Sending config change signal to child for #{name}")
-      Orchestrator.MonitorScheduler.config_change(name)
-    end)
-  end
-
 end


### PR DESCRIPTION
So that changes from for example AWS Secrets Manager propagate without requiring restarts.

After starting adding refresh, decided to drop caching instead. Extra cost is negligible and this propagates secrets changes the fastest way possible.

PR also includes some assorted minor cleanups of the code.