### PR TITLE
MET-1212 Only invalidate CloudFront once

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -122,3 +122,23 @@ jobs:
         run: .github/secret-to-env.sh
       - name: Deploy Orchestrator container
         run: ./deploy.sh
+
+  cloudfront-invalidation:
+    runs-on: ubuntu-latest
+    needs:
+      - build-push-dist
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::147803588724:role/github-action
+          aws-region: us-west-2
+
+      - name: Invalidate cloudfront
+        run: ./dist/invalidate_cloudfront.sh

--- a/dist/build.sh
+++ b/dist/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 #
 #  Run a build through docker. The actual build steps are in do-build.sh
+#
+#  Arguments:
+#  $1 - distribution name ('ubuntu')
+#  $2 - version ('22.04')
 
 set -e
 
@@ -23,4 +27,3 @@ gpg --sign --armor --detach-sign pkg/$pkg
 aws s3 cp pkg/$pkg s3://dist.metrist.io/orchestrator/$dist/
 aws s3 cp pkg/$pkg.asc s3://dist.metrist.io/orchestrator/$dist/
 echo $pkg | aws s3 cp - s3://dist.metrist.io/orchestrator/$dist/$ver.$arch.latest.txt
-aws cloudfront create-invalidation --distribution-id E1FRDOED06X2I8 --paths "/orchestrator/$dist/*"

--- a/dist/invalidate_cloudfront.sh
+++ b/dist/invalidate_cloudfront.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "Invalidating cloudfront Orchestrator distributions"
+
+aws cloudfront create-invalidation --distribution-id E1FRDOED06X2I8 --paths "/orchestrator/$dist/*" --no-cli-pager


### PR DESCRIPTION
This avoids errors from CloudFront when invalidate actions are called too often.