### PR TITLE
Hotfix cloudfront invalidation on build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -127,6 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-push-dist
+      - deploy
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     permissions:
       id-token: write

--- a/dist/invalidate_cloudfront.sh
+++ b/dist/invalidate_cloudfront.sh
@@ -4,4 +4,4 @@ set -eo pipefail
 
 echo "Invalidating cloudfront Orchestrator distributions"
 
-aws cloudfront create-invalidation --distribution-id E1FRDOED06X2I8 --paths "/orchestrator/$dist/*" --no-cli-pager
+aws cloudfront create-invalidation --distribution-id E1FRDOED06X2I8 --paths "/orchestrator/*" --no-cli-pager


### PR DESCRIPTION
We no longer have $dist so can't use that in the cloudfront invalidation and since deploy.sh also writes latest.txt files to dist we should wait for that to be complete as well before invalidating (both write to a folder under orchestrator/*)

Tested on dev