### PR TITLE
Ensure we honour proxy environment variables

### DIFF
--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -157,7 +157,7 @@ end
     proxy = System.get_env("https_proxy") || System.get_env("HTTPS_PROXY")
     case proxy do
       nil -> opts
-      hostport ->
+      _hostport ->
         [host, port] = String.split(proxy, ":")
         {port, _} = Integer.parse(port)
         Keyword.put(opts, :proxy, {host, port})

--- a/lib/orchestrator/application.ex
+++ b/lib/orchestrator/application.ex
@@ -152,4 +152,17 @@ end
         Orchestrator.Configuration.translate_value(token)
     end
   end
+
+  def with_proxy(opts) do
+    proxy = System.get_env("https_proxy") || System.get_env("HTTPS_PROXY")
+    case proxy do
+      nil -> opts
+      hostport ->
+        [host, port] = String.split(proxy, ":")
+        {port, _} = Integer.parse(port)
+        Keyword.put(opts, :proxy, {host, port})
+    end
+  end
+
+  def proxy_opts, do: with_proxy([])
 end

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -164,7 +164,7 @@ defmodule Orchestrator.Invoker do
   end
 
   def download(path) do
-    {:ok, %HTTPoison.Response{body: body}} = HTTPoison.get(@monitor_distributions_url <> path)
+    {:ok, %HTTPoison.Response{body: body}} = HTTPoison.get(@monitor_distributions_url <> path, [], Orchestrator.Application.proxy_opts())
     body
   end
 

--- a/lib/orchestrator/metrist_api.ex
+++ b/lib/orchestrator/metrist_api.ex
@@ -24,7 +24,9 @@ defmodule Orchestrator.MetristAPI do
 
     # This works for the most part as long as the appropriate HTTP status codes are returned
     # See https://hexdocs.pm/httpoison/HTTPoison.MaybeRedirect.html for details
-    Keyword.put_new(opts, :follow_redirect, true)
+    opts
+    |> Keyword.put_new(:follow_redirect, true)
+    |> Orchestrator.Application.with_proxy()
   end
 
   @impl true

--- a/lib/orchestrator/monitor_running_alerting.ex
+++ b/lib/orchestrator/monitor_running_alerting.ex
@@ -140,7 +140,7 @@ defmodule Orchestrator.MonitorRunningAlerting do
       }
       |> Jason.encode!()
 
-      HTTPoison.post(url, body, headers)
+      HTTPoison.post(url, body, headers, Orchestrator.Application.proxy_opts())
     end
   end
 

--- a/lib/orchestrator/slack_reporter.ex
+++ b/lib/orchestrator/slack_reporter.ex
@@ -43,7 +43,7 @@ defmodule Orchestrator.SlackReporter do
       {"Content-Type", "application/json; charset=UTF-8"}
     ]
 
-    HTTPoison.post(@slack_url, message, headers)
+    HTTPoison.post(@slack_url, message, headers, Orchestrator.Application.proxy_opts())
   end
 
   def is_configured?() do


### PR DESCRIPTION
WISOTT. 

Tested with `tcpdump host 54.186.126.55 or host 54.203.73.8` running to keep an eye on traffic to app.metrist.io and with Squid on a different box, with and without the proxy variables, and it operated as expected.  