### PR TITLE
MET-1280 built-in ping monitor

### DIFF
--- a/lib/mix/tasks/metrist/run_monitor.ex
+++ b/lib/mix/tasks/metrist/run_monitor.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Metrist.RunMonitor do
     }
     |> Orchestrator.Configuration.translate_config()
 
-    Logger.info("Running #{cfg.monitor_logical_name} with config #{inspect cfg}")
+    Logger.info("Running #{cfg.monitor_logical_name} with config #{Orchestrator.Configuration.inspect cfg}")
 
     get_invoker(opts[:run_type]).
     (

--- a/lib/orchestrator/configuration.ex
+++ b/lib/orchestrator/configuration.ex
@@ -118,11 +118,20 @@ defmodule Orchestrator.Configuration do
     |> Map.new()
   end
 
+  @doc """
+  Inspect function for configurations. Just a mash-up of `redact/1` and `inspect/1`.
+  """
+  def inspect(config) do
+    config
+    |> redact()
+    |> Kernel.inspect()
+  end
+
   defp find_added(new_config, old_config) do
     new_list = Map.get(new_config, :monitors, [])
     old_list = Map.get(old_config, :monitors, [])
     Enum.filter(new_list, fn cfg -> find_by_unique_key(old_list, cfg) == nil end)
-  end
+   end
 
   defp find_deleted(new_config, old_config) do
     new_list = Map.get(new_config, :monitors, [])

--- a/lib/orchestrator/dotnet_dll_invoker.ex
+++ b/lib/orchestrator/dotnet_dll_invoker.ex
@@ -26,7 +26,6 @@ defmodule Orchestrator.DotNetDLLInvoker do
       end
 
     cmd = "#{runner} #{config.monitor_logical_name} #{executable_folder}"
-    Logger.debug("#{inspect(cmd)}")
 
     Invoker.run_monitor(config, opts, fn tmp_dir ->
       Invoker.start_monitor(cmd, [], tmp_dir)

--- a/lib/orchestrator/executable_invoker.ex
+++ b/lib/orchestrator/executable_invoker.ex
@@ -11,7 +11,7 @@ defmodule Orchestrator.ExecutableInvoker do
 
   @impl true
   def invoke(config, opts \\ []) do
-    Logger.debug("Invoking #{inspect(config)}")
+    Logger.debug("Invoking #{Orchestrator.Configuration.inspect(config)}")
 
     # :executable is set for a manual monitor run
     executable =

--- a/lib/orchestrator/monitor_supervisor.ex
+++ b/lib/orchestrator/monitor_supervisor.ex
@@ -34,9 +34,9 @@ defmodule Orchestrator.MonitorSupervisor do
       [{pid, _}] = Registry.lookup(registry, id)
       case DynamicSupervisor.terminate_child(supervisor_name, pid) do
         :ok ->
-          Logger.info("Terminated child #{inspect id} with config #{inspect monitor_config} running as #{inspect pid}")
+          Logger.info("Terminated child #{inspect id} with config #{Orchestrator.Configuration.inspect monitor_config} running as #{inspect pid}")
         {:error, err} ->
-          Logger.error("Could not terminate child #{inspect id} with config #{inspect monitor_config}, error: #{inspect err}")
+          Logger.error("Could not terminate child #{inspect id} with config #{Orchestrator.Configuration.inspect monitor_config}, error: #{inspect err}")
       end
     end)
   end

--- a/lib/orchestrator/nil_invoker.ex
+++ b/lib/orchestrator/nil_invoker.ex
@@ -9,7 +9,7 @@ defmodule Orchestrator.NilInvoker do
   @impl true
   def invoke(config, _opts \\ []) do
     Task.async(fn ->
-      Logger.info("Nil invocation on #{inspect config}")
+      Logger.info("Nil invocation on #{Orchestrator.Configuration.inspect config}")
       :nil_invoke_complete
     end)
   end

--- a/lib/orchestrator/ping_invoker.ex
+++ b/lib/orchestrator/ping_invoker.ex
@@ -1,0 +1,96 @@
+defmodule Orchestrator.PingInvoker do
+  @moduledoc """
+  A built-in invoker type that just does an ICMP Ping to an endpoint. Can be used as a very basic
+  check for new monitors.
+
+  The check name is hardcoded, any steps configured are ignored.
+
+  There is only one configuration setting:
+  - `target` - the name/IP of the host to ping.
+
+  """
+
+  require Logger
+
+  @behaviour Orchestrator.Invoker
+
+  @impl true
+  def invoke(config, opts \\ []) do
+    Task.async(fn ->
+      target = Map.get(config.extra_config, "Target")
+
+      error_report_fun =
+        Keyword.get(opts, :error_report_fun, &Orchestrator.APIClient.write_error/4)
+
+      telemetry_report_fun =
+        Keyword.get(opts, :telemetry_report_fun, &Orchestrator.APIClient.write_telemetry/4)
+
+      report_error = fn error ->
+        Logger.error("Ping of #{target} resulted in error: #{error}")
+        error_report_fun.(config.monitor_logical_name, "Ping", error, [])
+      end
+
+      report_telem = fn telem ->
+        Logger.info("Ping of #{target} complete, average time is #{telem}ms.")
+        telemetry_report_fun.(config.monitor_logical_name, "Ping", telem, [])
+      end
+
+      Logger.debug("Invoking ping #{target}")
+      {output, exit_code} = System.cmd("ping", ["-c5", "-W5", target], stderr_to_stdout: true)
+      Logger.debug("Ping exited with #{exit_code}, output: #{output}")
+
+      case exit_code do
+        0 ->
+          case parse_output(output) do
+            {:ok, telem} ->
+              report_telem.(telem)
+
+            :error ->
+              # We don't report an error, as it is not the target's fault that something seems to be
+              # off with the environment where Orchestrator is running.
+              Logger.error(
+                "Ping of #{target} could not parse output, unknown version of ping command on system?"
+              )
+          end
+
+        other ->
+          report_error.("Ping command exited with error status #{other}.")
+      end
+
+      :ping_complete
+    end)
+  end
+
+  def parse_output(output) do
+    # "rtt min/avg/max/mdev = 46.799/53.179/59.289/4.423 ms"
+
+    stats_line =
+      output
+      |> String.trim()
+      |> String.split("\n")
+      |> List.last()
+
+    parse_line = fn line ->
+      {value, _} =
+        line
+        |> String.split("/")
+        |> Enum.at(1)
+        |> Float.parse()
+
+      value
+    end
+
+    case stats_line do
+      # Regular iputils ping
+      "rtt min/avg/max/mdev = " <> rest ->
+        {:ok, parse_line.(rest)}
+
+      # Busybox
+      "round-trip min/avg/max = " <> rest ->
+        {:ok, parse_line.(rest)}
+
+      other ->
+        :error
+    end
+  end
+end

--- a/lib/orchestrator/ping_invoker.ex
+++ b/lib/orchestrator/ping_invoker.ex
@@ -17,7 +17,7 @@ defmodule Orchestrator.PingInvoker do
   @impl true
   def invoke(config, opts \\ []) do
     Task.async(fn ->
-      target = Map.get(config.extra_config, "Target")
+      target = Map.get(config.extra_config, :"Target")
 
       error_report_fun =
         Keyword.get(opts, :error_report_fun, &Orchestrator.APIClient.write_error/4)
@@ -35,9 +35,9 @@ defmodule Orchestrator.PingInvoker do
         telemetry_report_fun.(config.monitor_logical_name, "Ping", telem, [])
       end
 
-      Logger.debug("Invoking ping #{target}")
+      Logger.info("Invoking ping #{target}")
       {output, exit_code} = System.cmd("ping", ["-c5", "-W5", target], stderr_to_stdout: true)
-      Logger.debug("Ping exited with #{exit_code}, output: #{output}")
+      Logger.info("Ping exited with #{exit_code}, output: #{output}")
 
       case exit_code do
         0 ->

--- a/lib/orchestrator/ping_invoker.ex
+++ b/lib/orchestrator/ping_invoker.ex
@@ -89,7 +89,7 @@ defmodule Orchestrator.PingInvoker do
       "round-trip min/avg/max = " <> rest ->
         {:ok, parse_line.(rest)}
 
-      other ->
+      _other ->
         :error
     end
   end

--- a/test/orchestrator/ping_invoker_test.exs
+++ b/test/orchestrator/ping_invoker_test.exs
@@ -1,0 +1,23 @@
+defmodule Orchestrator.PingInvokerTest do
+  use ExUnit.Case, async: true
+
+  alias Orchestrator.PingInvoker
+
+  test "Parsing valid iputils ping output" do
+    output = "PING amazonaws.com (72.21.206.80) 56(84) bytes of data.\n64 bytes from 206-80.amazon.com (72.21.206.80): icmp_seq=1 ttl=223 time=49.7 ms\n64 bytes from 206-80.amazon.com (72.21.206.80): icmp_seq=2 ttl=223 time=59.3 ms\n64 bytes from 206-80.amazon.com (72.21.206.80): icmp_seq=3 ttl=223 time=46.8 ms\n64 bytes from 206-80.amazon.com (72.21.206.80): icmp_seq=4 ttl=223 time=55.6 ms\n64 bytes from 206-80.amazon.com (72.21.206.80): icmp_seq=5 ttl=223 time=54.5 ms\n\n--- amazonaws.com ping statistics ---\n5 packets transmitted, 5 received, 0% packet loss, time 4005ms\nrtt min/avg/max/mdev = 46.799/53.179/59.289/4.423 ms\n"
+
+    {:ok, 53.179} = PingInvoker.parse_output(output)
+  end
+
+  test "Parsing valid BusyBox ping output" do
+    output = "PING amazonaws.com (72.21.206.80): 56 data bytes\n64 bytes from 72.21.206.80: seq=0 ttl=224 time=49.578 ms\n64 bytes from 72.21.206.80: seq=1 ttl=224 time=48.962 ms\n64 bytes from 72.21.206.80: seq=2 ttl=224 time=48.183 ms\n\n--- amazonaws.com ping statistics ---\n3 packets transmitted, 3 packets received, 0% packet loss\nround-trip min/avg/max = 48.183/48.907/49.578 ms\n"
+
+    {:ok, 48.907} = PingInvoker.parse_output(output)
+  end
+
+  test "Invalid output returns error" do
+    output = "You wanted to ping\nbut there is no ping\nWe're noping the ping\n"
+
+    :error = PingInvoker.parse_output(output)
+  end
+end


### PR DESCRIPTION
Nice test to see how flexible the monitor invocation framework is in Orchestrator, the Ping monitor is built-in so it becomes a very cheap way to do basic checks against a bunch of endpoints.

Note that a lot of sites block ICMP. If this is deemed useful, we probably want to extend this to SYN checking (making an actual connection). 

New monitor:

![image](https://user-images.githubusercontent.com/84811/229161410-d7ab9974-eba4-4b2d-9de3-ad3427dcd37f.png)

Addition to existing monitor:

![image](https://user-images.githubusercontent.com/84811/229161580-d100a283-e724-4d30-8e9a-367d0df89582.png)

Blocked API (don't do this in production ;-)): 

![image](https://user-images.githubusercontent.com/84811/229161680-b33ef76d-caa6-464b-8833-d7c0816e8d1d.png)

## Deploy

* [ ] Merge https://github.com/Metrist-Software/backend/pull/923
* [ ] Merge this
* [ ] When deployed, use curl to add some ping monitors in production. New monitors need to have their name set with a Mix task, no API for that yet.