### PR TITLE
Use main for GITHUB_REF

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -6,7 +6,7 @@
 set -eou pipefail
 
 case "${GITHUB_REF:-}" in
-    refs/heads/master)
+    refs/heads/main)
         qualifier=""
         ;;
     *)

--- a/dist/build-base.sh
+++ b/dist/build-base.sh
@@ -6,7 +6,7 @@ dist=$1
 ver=$2
 
 case "${GITHUB_REF:-}" in
-    refs/heads/master)
+    refs/heads/main)
         qualifier=""
         ;;
     *)

--- a/dist/build.sh
+++ b/dist/build.sh
@@ -14,7 +14,7 @@ dist=$1
 ver=$2
 
 case "${GITHUB_REF:-}" in
-    refs/heads/master)
+    refs/heads/main)
         qualifier=""
         ;;
     *)

--- a/dist/e2e.sh
+++ b/dist/e2e.sh
@@ -37,7 +37,7 @@ $TEST_API_TOKEN
 e2e_test_$DIST
 EOF
 
-sleep 45
+sleep 60
 
 LOGS=$(sudo journalctl --unit metrist-orchestrator --since "1m ago" --no-pager)
 echo "$LOGS"


### PR DESCRIPTION
The last orchestrator deploy was using the -preview tag because it looking at the `master` branch. This PR changes to look for `main` branch and increases the timeout for e2e test