### PR TITLE
Add libicu to deps

### DIFF
--- a/dist/rocky/8/Vagrantfile
+++ b/dist/rocky/8/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     # Basic stuff
     dnf update
-    dnf install -y curl sudo zstd git curl unzip wget
+    dnf install -y curl sudo zstd git curl unzip wget libicu
 
     # Quality-of-life tweaks to login shells go here
     cat >>/home/vagrant/.profile <<EOF

--- a/dist/rocky/8/fpm.cmd
+++ b/dist/rocky/8/fpm.cmd
@@ -1,1 +1,1 @@
--t rpm -d procps-ng -d glibc -d ncurses -d openssl-devel -d libgcc -d libstdc++ -d lksctp-tools
+-t rpm -d procps-ng -d glibc -d ncurses -d openssl-devel -d libgcc -d libstdc++ -d lksctp-tools -d libicu


### PR DESCRIPTION
The dll runner was getting this error because `libicu` was not installed in rocky
```
[vagrant@localhost ~]$ /tmp/.metrist-bwcache/F258B0A731C33248C1875535400C9A57F9553C8C/lib/orchestrator-0.1.0/priv/runner/Metrist.Runner testsignal /root/.cache/metrist/monitors/testsignal
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
   at System.Environment.FailFast(System.String)
   at System.Globalization.GlobalizationMode+Settings..cctor()
   at System.Globalization.CultureData.CreateCultureWithInvariantData()
   at System.Globalization.CultureData.get_Invariant()
   at System.Globalization.TextInfo..cctor()
   at System.Diagnostics.Tracing.EventSource.GetGuid(System.Type)
   at System.Diagnostics.Tracing.EventSource..ctor(System.Diagnostics.Tracing.EventSourceSettings, System.String[])
   at System.Diagnostics.Tracing.EventSource..ctor(System.Diagnostics.Tracing.EventSourceSettings)
   at Microsoft.Extensions.DependencyInjection.DependencyInjectionEventSource..ctor()
   at Microsoft.Extensions.DependencyInjection.DependencyInjectionEventSource..cctor()
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(System.Collections.Generic.ICollection`1<Microsoft.Extensions.DependencyInjection.ServiceDescriptor>, Microsoft.Extensions.DependencyInjection.ServiceProviderOptions)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceProviderOptions)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(Microsoft.Extensions.DependencyInjection.IServiceCollection)
   at Metrist.Runner.Program.InitializeLogging()
   at Metrist.Runner.Program.Run(System.String, System.String)
   at Metrist.Runner.Program.Main(System.String[])
Aborted (core dumped)
```