### PR TITLE
MET-1296

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -6,10 +6,11 @@ build your own or add new distribution targets.
 
 ## Versioning
 
-Distribution packages are tagged with three version elements:
+Distribution packages are tagged with four version elements:
 
 * The Mix version, taken from Orchestrator's [`mix.exs`](../mix.exs);
 * The target (distribution and distribution version, for example `ubuntu-20.04`);
+* The time the package was built (yymmddhhmm);
 * The Git short rev of this repository.
 
 The latter element is just informational, updates to Orchestrator packages will be indicated through mix version bumps.

--- a/dist/do-build.sh
+++ b/dist/do-build.sh
@@ -16,7 +16,7 @@ mix local.hex --force
 mix local.rebar --force
 
 cd $base
-tag=$(git rev-parse --short HEAD)
+tag=$(date +%Y%m%d%H%M)-$(git rev-parse --short HEAD)
 ./install-runner.sh
 make generate_build_info
 mix do deps.get, compile, release

--- a/dist/rocky/8/Vagrantfile
+++ b/dist/rocky/8/Vagrantfile
@@ -5,7 +5,7 @@
 #  See https://developer.hashicorp.com/vagrant/docs/installation for instructions.
 #
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/rockylinux-8.7"
+  config.vm.box = "generic/rocky8"
   # Libvirt is preferred given issues around VirtualBox, Oracle licensing, and
   # commercial use we need to sort out first.
   config.vm.provider "libvirt" do |vm|


### PR DESCRIPTION
Ensure that newer packages are always seen as an upgrade to apt/rpm by including a timestamp. Tested on Ubuntu 22.04 and Rocky 8 that this let apt/yum interpret package versions correctly as either upgrade or downgrade.

### Deploy

* [ ] Merge