### PR TITLE
MET-1295 - Check/update configure-aws-credentials action in GH Workflows

### DIFF
--- a/.github/workflows/dist-e2e.yml
+++ b/.github/workflows/dist-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2-node16
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2

--- a/.github/workflows/night-dev-reset.yml
+++ b/.github/workflows/night-dev-reset.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2

--- a/.github/workflows/weekly-refresh-base.yml
+++ b/.github/workflows/weekly-refresh-base.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::147803588724:role/github-action
           aws-region: us-west-2


### PR DESCRIPTION
### Description
The deprecation message logged is from the version of the aws sdk used by the configure-aws-credentials action. Unfortunately they don't have a version available that uses v3 of the sdk, so we can't get rid of the message for now. It's apparently a major rewrite for the action that is currently being worked on: https://github.com/aws-actions/configure-aws-credentials/issues/680#issuecomment-1457222239

There's also the issue `can't issue id_token for job in 'pending' state` error as reported in the ticket. Seems to be a reported bug/race condition when running multiple actions at once (as we do with in the monitors repo). Relevant issue: https://github.com/aws-actions/configure-aws-credentials/issues/469

Doesn't seem like we can do anything about either of these, but updating the action to v2 will at least get us non-major updates if/when they come out (v1 has stopped getting updates at this point)

### Jira Item (if applicable)
MET-1295

### Tested (If not tested in dev, explain)
- [ ] local
- [x] dev

### Deployment Steps
- [ ] Merge
