### PR TITLE
MET-1337 Orchestrator Monitor Caching isn't working

### DIFF
--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -160,7 +160,15 @@ defmodule Orchestrator.Invoker do
 
   defp available?(name, version) do
     loc = cache_location(name, version)
-    File.dir?(loc) and File.exists?(Path.join(loc, name))
+    File.dir?(loc) and (exe_exists(name, loc) or dll_exists(name, loc))
+  end
+
+  defp exe_exists(name, loc) do
+    File.exists?(Path.join(loc, name))
+  end
+
+  defp dll_exists(name, loc) do
+    Path.wildcard(Path.join(loc, "*#{name}.dll")) != []
   end
 
   def download(path) do

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -168,7 +168,7 @@ defmodule Orchestrator.Invoker do
   end
 
   defp dll_exists(name, loc) do
-    Path.wildcard(Path.join(loc, "*#{name}.dll")) != []
+    Path.wildcard(Path.join(loc, "*.dll")) != []
   end
 
   def download(path) do

--- a/lib/orchestrator/invoker.ex
+++ b/lib/orchestrator/invoker.ex
@@ -160,14 +160,14 @@ defmodule Orchestrator.Invoker do
 
   defp available?(name, version) do
     loc = cache_location(name, version)
-    File.dir?(loc) and (exe_exists(name, loc) or dll_exists(name, loc))
+    File.dir?(loc) and (exe_exists(name, loc) or dll_exists(loc))
   end
 
   defp exe_exists(name, loc) do
     File.exists?(Path.join(loc, name))
   end
 
-  defp dll_exists(name, loc) do
+  defp dll_exists(loc) do
     Path.wildcard(Path.join(loc, "*.dll")) != []
   end
 


### PR DESCRIPTION
### Description
Caching was working for exe monitors, but not dll monitors due to not having a singular `<monitor_logical_name>` file as part of the distributable. A little awkward since the dist names for dll monitors don't match the logical name (they include `Metrist.Monitors.` and have different capitalization) so instead we just check if there's any `.dll` file available in the cache directory

### Deployment Steps
- [ ] Merge
